### PR TITLE
Stop publishing to `heroku/heroku-private` on Docker Hub

### DIFF
--- a/bin/publish-to-registries.sh
+++ b/bin/publish-to-registries.sh
@@ -29,25 +29,20 @@ push_group() {
     done
 }
 
-date=$(date -u '+%Y-%m-%d-%H.%M.%S')
 publicTag="heroku/heroku:${STACK_VERSION}"
-privateTag="heroku/heroku-private:${STACK_VERSION}"
 internalTag="${INTERNAL_REGISTRY_HOST}/s/${ID_SERVICE_USERNAME}/heroku:${STACK_VERSION}"
 
-# Push nightly tags to dockerhub (e.g. heroku/heroku:22.nightly)
+# Push nightly tags to Docker Hub (e.g. heroku/heroku:22.nightly)
 push_group "${publicTag}" ".nightly"
 
-# Push date tags to private dockerhub (e.g. heroku/heroku-private:22.2022-06-01-17.00.00)
-push_group "${privateTag}" ".${date}"
-
 if [ "$GITHUB_REF_TYPE" == 'tag' ]; then
-  # Push release tags to dockerhub (e.g. heroku/heroku:22.v99)
+  # Push release tags to Docker Hub (e.g. heroku/heroku:22.v99)
   push_group "${publicTag}" ".${GITHUB_REF_NAME}"
 
   # Push release tags to internal registry
   push_group "${internalTag}" ".${GITHUB_REF_NAME}"
 
-  # Push latest/no-suffix tags to dockerhub (e.g. heroku/heroku:22)
+  # Push latest/no-suffix tags to Docker Hub (e.g. heroku/heroku:22)
   push_group "${publicTag}" ""
 
   # Push latest/no-suffix tags to internal registry


### PR DESCRIPTION
The base images are currently double-published to Docker Hub - once to the **public** `heroku/heroku` repository, and then again to the **private** `heroku/heroku-private` repo.

Publishing to `heroku/heroku-private` was added in:
https://github.com/heroku/base-images/pull/130

...with the explanation that it might help internally with rollback use-cases.

However:
1. We've never had cause to use this private Docker Hub repository for rollback in the 5 years since.
2. We now have a robust image rollout and rollback process (which is new since the incident that prompted the above PR), which doesn't use these images, but instead Cheverny (for the S3 image releases) and versioned release image tags on the `heroku/heroku` repo for the Docker image side: https://github.com/heroku/cheverny/blob/main/docs/base-image-release.md#rollback-process
3. The author of the PR that added the publishing of these images has confirmed that there isn't some other reason for keeping them: https://salesforce-internal.slack.com/archives/C01068P24S3/p1707346168976339

As such, we can stop publishing to this repository to simplify the publishing process (which is going to be getting a lot more complex for multi-arch support soon).

GUS-W-15018626.