### PR TITLE
Stop publishing to the internal container registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,6 @@ jobs:
       STACK_VERSION: "${{ matrix.stack-version }}"
       DOCKER_HUB_TOKEN: "${{ secrets.DOCKER_HUB_TOKEN }}"
       DOCKER_HUB_USERNAME: "${{ secrets.DOCKER_HUB_USERNAME }}"
-      ID_SERVICE_PASSWORD: "${{ secrets.ID_SERVICE_PASSWORD }}"
-      ID_SERVICE_TOKEN_ENDPOINT: "${{ secrets.ID_SERVICE_TOKEN_ENDPOINT }}"
-      ID_SERVICE_USERNAME: "${{ secrets.ID_SERVICE_USERNAME }}"
-      INTERNAL_REGISTRY_HOST: "${{ secrets.INTERNAL_REGISTRY_HOST }}"
-      INTERNAL_REGISTRY_USERNAME: "${{ secrets.INTERNAL_REGISTRY_USERNAME }}"
       MANIFEST_APP_TOKEN: "${{ secrets.MANIFEST_APP_TOKEN }}"
       MANIFEST_APP_URL: "${{ secrets.MANIFEST_APP_URL }}"
     strategy:

--- a/bin/publish-to-registries.sh
+++ b/bin/publish-to-registries.sh
@@ -11,11 +11,6 @@ bin/build.sh "${STACK_VERSION}"
 
   echo "Logging into Docker Hub..."
   echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USERNAME}" --password-stdin
-
-  echo "Logging into internal container registry..."
-  curl -sSf --retry 3 -X POST "$ID_SERVICE_TOKEN_ENDPOINT" -d "{\"username\":\"${ID_SERVICE_USERNAME}\",\"password\":\"${ID_SERVICE_PASSWORD}\"}" \
-    | jq -er ".raw_id_token" \
-    | docker login "$INTERNAL_REGISTRY_HOST" -u "$INTERNAL_REGISTRY_USERNAME" --password-stdin
 )
 
 push_group() {
@@ -30,7 +25,6 @@ push_group() {
 }
 
 publicTag="heroku/heroku:${STACK_VERSION}"
-internalTag="${INTERNAL_REGISTRY_HOST}/s/${ID_SERVICE_USERNAME}/heroku:${STACK_VERSION}"
 
 # Push nightly tags to Docker Hub (e.g. heroku/heroku:22.nightly)
 push_group "${publicTag}" ".nightly"
@@ -39,12 +33,6 @@ if [ "$GITHUB_REF_TYPE" == 'tag' ]; then
   # Push release tags to Docker Hub (e.g. heroku/heroku:22.v99)
   push_group "${publicTag}" ".${GITHUB_REF_NAME}"
 
-  # Push release tags to internal registry
-  push_group "${internalTag}" ".${GITHUB_REF_NAME}"
-
   # Push latest/no-suffix tags to Docker Hub (e.g. heroku/heroku:22)
   push_group "${publicTag}" ""
-
-  # Push latest/no-suffix tags to internal registry
-  push_group "${internalTag}" ""
 fi


### PR DESCRIPTION
Currently the base images are published not only to Docker Hub, but also an internal container registry.

However, the last remaining consumer of the base-images from the internal registry is migrating away from these images as of:
https://github.com/heroku/kodon/pull/483

As such, there is no longer any need to publish to this registry, which simplifies the publishing process here, and means one less set of credentials to manage/rotate.

GUS-W-15019312.