### PR TITLE
Don't attempt to docker push image manifests

### DIFF
--- a/bin/publish-to-registries.sh
+++ b/bin/publish-to-registries.sh
@@ -25,11 +25,11 @@ push_group() {
       if (( STACK_VERSION < 24 )); then
         # Re-tag amd64-only images
         docker tag "${source}" "${target}"
+        docker push "${target}"
       else
         # Make a carbon copy image index for multi-arch images
         docker buildx imagetools create -t "${target}" "${source}"
       fi
-      docker push "${target}"
     done
 }
 


### PR DESCRIPTION
CI is failing [here](https://github.com/heroku/base-images/actions/runs/8144660131/job/22259237463), with the following error:

```
+ docker push heroku/heroku:24.nightly
The push refers to repository [docker.io/heroku/heroku]
tag does not exist: heroku/heroku:24.nightly
```

That's because we're attempting to `docker push` a multi-arch image manifest. `docker push` supports images, not manifests. The equivalent command for a manifest list is `docker manifest push`, but we actually don't need that - the `docker buildx manifest create` command already publishes the image (as you can see [here](https://hub.docker.com/layers/heroku/heroku/24.nightly/images/sha256-2e4ed565d4487a971b5608d020e60c8d62d702dd533f7db9e1b47f7506050355?context=explore)).