### PR TITLE
Use `--error-on=any` with `apt-get update`

### DIFF
--- a/heroku-20-build/setup.sh
+++ b/heroku-20-build/setup.sh
@@ -8,7 +8,7 @@ set -x
 
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get update
+apt-get update --error-on=any
 apt-get install -y --no-install-recommends \
     autoconf \
     automake \

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -15,7 +15,7 @@ deb http://archive.ubuntu.com/ubuntu/ focal-security main universe
 deb http://archive.ubuntu.com/ubuntu/ focal-updates main universe
 EOF
 
-apt-get update
+apt-get update --error-on=any
 
 # Required by apt-key and does not exist in the base image on newer Ubuntu.
 apt-get install -y --no-install-recommends gnupg
@@ -28,7 +28,7 @@ deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main
 EOF
 apt-key add /build/postgresql-ACCC4CF8.asc
 
-apt-get update
+apt-get update --error-on=any
 apt-get upgrade -y
 apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/heroku-22-build/setup.sh
+++ b/heroku-22-build/setup.sh
@@ -8,7 +8,7 @@ set -x
 
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get update
+apt-get update --error-on=any
 apt-get install -y --no-install-recommends \
     autoconf \
     automake \

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -15,7 +15,7 @@ deb http://archive.ubuntu.com/ubuntu/ jammy-security main universe
 deb http://archive.ubuntu.com/ubuntu/ jammy-updates main universe
 EOF
 
-apt-get update
+apt-get update --error-on=any
 
 # Required by apt-key and does not exist in the base image on newer Ubuntu.
 apt-get install -y --no-install-recommends gnupg
@@ -28,7 +28,7 @@ deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main
 EOF
 apt-key add /build/postgresql-ACCC4CF8.asc
 
-apt-get update
+apt-get update --error-on=any
 apt-get upgrade -y
 apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/heroku-24-build/setup.sh
+++ b/heroku-24-build/setup.sh
@@ -8,7 +8,7 @@ set -x
 
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get update
+apt-get update --error-on=any
 apt-get install -y --no-install-recommends \
     autoconf \
     automake \

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -40,7 +40,7 @@ Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 Architectures: arm64
 EOF
 
-apt-get update
+apt-get update --error-on=any
 
 # Required by apt-key and does not exist in the base image on newer Ubuntu.
 apt-get install -y --no-install-recommends gnupg
@@ -53,7 +53,7 @@ deb http://apt.postgresql.org/pub/repos/apt/ noble-pgdg main
 EOF
 apt-key add /build/postgresql-ACCC4CF8.asc
 
-apt-get update
+apt-get update --error-on=any
 apt-get upgrade -y --no-install-recommends
 apt-get install -y --no-install-recommends \
     apt-transport-https \


### PR DESCRIPTION
Since otherwise APT will ignore certain categories of errors that it sees as transient (such as failing to pull from one repo, even for things like TLS validation errors; this was discovered whilst working on #248).

See:
https://manpages.ubuntu.com/manpages/noble/man8/apt-get.8.html

GUS-W-15224473.