### PR TITLE
Cleanup setup scripts

### DIFF
--- a/heroku-20-build/setup.sh
+++ b/heroku-20-build/setup.sh
@@ -1,92 +1,91 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
-# Redirect stderr to stdout since tracing/apt-get/dpkg spam it for things that aren't errors.
-exec 2>&1
-set -x
+set -euxo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
+packages=(
+  autoconf
+  automake
+  bison
+  build-essential
+  bzr
+  cmake
+  gettext
+  git
+  jq
+  libacl1-dev
+  libapt-pkg-dev
+  libargon2-dev
+  libattr1-dev
+  libaudit-dev
+  libbsd-dev
+  libbz2-dev
+  libc-client2007e-dev
+  libcairo2-dev
+  libcap-dev
+  libcurl4-openssl-dev
+  libdb-dev
+  libev-dev
+  libevent-dev
+  libexif-dev
+  libffi-dev
+  libgcrypt20-dev
+  libgd-dev
+  libgdbm-dev
+  libgeoip-dev
+  libglib2.0-dev
+  libgnutls28-dev
+  libgs-dev
+  libicu-dev
+  libidn11-dev
+  libjpeg-dev
+  libkeyutils-dev
+  libkmod-dev
+  libkrb5-dev
+  libldap2-dev
+  liblz4-dev
+  liblzf-dev
+  libmagic-dev
+  libmagickwand-dev
+  libmcrypt-dev
+  libmemcached-dev
+  libmysqlclient-dev
+  libncurses5-dev
+  libncursesw5-dev
+  libnetpbm10-dev
+  libonig-dev
+  libpam0g-dev
+  libpopt-dev
+  libpq-dev
+  librabbitmq-dev
+  libreadline-dev
+  librtmp-dev
+  libseccomp-dev
+  libselinux1-dev
+  libsemanage1-dev
+  libsodium-dev
+  libssl-dev
+  libsystemd-dev
+  libtool
+  libudev-dev
+  libuv1-dev
+  libwrap0-dev
+  libxml2-dev
+  libxslt-dev
+  libyaml-dev
+  libzip-dev
+  libzstd-dev
+  mercurial
+  patchelf
+  postgresql-server-dev-15
+  python3-dev
+  ruby-dev
+  zlib1g-dev
+)
+
 apt-get update --error-on=any
-apt-get install -y --no-install-recommends \
-    autoconf \
-    automake \
-    bison \
-    build-essential \
-    bzr \
-    cmake \
-    gettext \
-    git \
-    jq \
-    libacl1-dev \
-    libapt-pkg-dev \
-    libargon2-dev \
-    libattr1-dev \
-    libaudit-dev \
-    libbsd-dev \
-    libbz2-dev \
-    libc-client2007e-dev \
-    libcairo2-dev \
-    libcap-dev \
-    libcurl4-openssl-dev \
-    libdb-dev \
-    libev-dev \
-    libevent-dev \
-    libexif-dev \
-    libffi-dev \
-    libgcrypt20-dev \
-    libgd-dev \
-    libgdbm-dev \
-    libgeoip-dev \
-    libglib2.0-dev \
-    libgnutls28-dev \
-    libgs-dev \
-    libicu-dev \
-    libidn11-dev \
-    libjpeg-dev \
-    libkeyutils-dev \
-    libkmod-dev \
-    libkrb5-dev \
-    libldap2-dev \
-    liblz4-dev \
-    liblzf-dev \
-    libmagic-dev \
-    libmagickwand-dev \
-    libmcrypt-dev \
-    libmemcached-dev \
-    libmysqlclient-dev \
-    libncurses5-dev \
-    libncursesw5-dev \
-    libnetpbm10-dev \
-    libonig-dev \
-    libpam0g-dev \
-    libpopt-dev \
-    libpq-dev \
-    librabbitmq-dev \
-    libreadline-dev \
-    librtmp-dev \
-    libseccomp-dev \
-    libselinux1-dev \
-    libsemanage1-dev \
-    libsodium-dev \
-    libssl-dev \
-    libsystemd-dev \
-    libtool \
-    libudev-dev \
-    libuv1-dev \
-    libwrap0-dev \
-    libxml2-dev \
-    libxslt-dev \
-    libyaml-dev \
-    libzip-dev \
-    libzstd-dev \
-    mercurial \
-    patchelf \
-    postgresql-server-dev-15 \
-    python3-dev \
-    ruby-dev \
-    zlib1g-dev \
+apt-get install -y --no-install-recommends "${packages[@]}"
 
 rm -rf /root/*
 rm -rf /tmp/*

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
-# Redirect stderr to stdout since tracing/apt-get/dpkg spam it for things that aren't errors.
-exec 2>&1
-set -x
+set -euxo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -30,130 +26,134 @@ apt-key add /build/postgresql-ACCC4CF8.asc
 
 apt-get update --error-on=any
 apt-get upgrade -y
-apt-get install -y --no-install-recommends \
-    apt-transport-https \
-    apt-utils \
-    bind9-host \
-    bzip2 \
-    coreutils \
-    curl \
-    dnsutils \
-    ed \
-    file \
-    fontconfig \
-    gcc \
-    geoip-database \
-    gettext-base \
-    ghostscript \
-    gir1.2-harfbuzz-0.0 \
-    git \
-    gsfonts \
-    imagemagick \
-    iproute2 \
-    iputils-tracepath \
-    language-pack-en \
-    less \
-    libaom0 \
-    libargon2-1 \
-    libass9 \
-    libc-client2007e \
-    libc6-dev \
-    libcairo2 \
-    libcroco3 \
-    libcurl4 \
-    libdatrie1 \
-    libev4 \
-    libevent-2.1-7 \
-    libevent-core-2.1-7 \
-    libevent-extra-2.1-7 \
-    libevent-openssl-2.1-7 \
-    libevent-pthreads-2.1-7 \
-    libexif12 \
-    libfreetype6 \
-    libfribidi0 \
-    libgd3 \
-    libgdk-pixbuf2.0-0 \
-    libgdk-pixbuf2.0-common \
-    libgnutls-openssl27 \
-    libgnutls30 \
-    libgnutlsxx28 \
-    libgraphite2-3 \
-    libgraphite2-3 \
-    libgs9 \
-    libharfbuzz-gobject0 \
-    libharfbuzz-icu0 \
-    libharfbuzz0b \
-    liblzf1 \
-    libmagickcore-6.q16-3-extra \
-    libmcrypt4 \
-    libmemcached11 \
-    libmp3lame0 \
-    libmysqlclient21 \
-    libnuma1 \
-    libogg0 \
-    libonig5 \
-    libopencore-amrnb0 \
-    libopencore-amrwb0 \
-    libopus0 \
-    libpango-1.0-0 \
-    libpangocairo-1.0-0 \
-    libpangoft2-1.0-0 \
-    libpixman-1-0 \
-    librabbitmq4 \
-    librsvg2-2 \
-    librsvg2-common \
-    libsasl2-modules \
-    libseccomp2 \
-    libsodium23 \
-    libspeex1 \
-    libthai-data \
-    libthai0 \
-    libtheora0 \
-    libunistring2 \
-    libuv1 \
-    libvips42 \
-    libvorbis0a \
-    libvorbisenc2 \
-    libvorbisfile3 \
-    libvpx6 \
-    libwebp6 \
-    libwebpdemux2 \
-    libwebpmux3 \
-    libx264-155 \
-    libx265-179 \
-    libxcb-render0 \
-    libxcb-shm0 \
-    libxrender1 \
-    libxslt1.1 \
-    libzip5 \
-    libzstd1 \
-    locales \
-    lsb-release \
-    make \
-    netcat-openbsd \
-    openssh-client \
-    openssh-server \
-    patch \
-    poppler-utils \
-    postgresql-client-15 \
-    python-is-python3 \
-    python3 \
-    rename \
-    rsync \
-    ruby \
-    shared-mime-info \
-    socat \
-    stunnel \
-    syslinux \
-    tar \
-    telnet \
-    tzdata \
-    unzip \
-    wget \
-    xz-utils \
-    zip \
-    zlib1g \
-    zstd \
+
+packages=(
+  apt-transport-https
+  apt-utils
+  bind9-host
+  bzip2
+  coreutils
+  curl
+  dnsutils
+  ed
+  file
+  fontconfig
+  gcc
+  geoip-database
+  gettext-base
+  ghostscript
+  gir1.2-harfbuzz-0.0
+  git
+  gsfonts
+  imagemagick
+  iproute2
+  iputils-tracepath
+  language-pack-en
+  less
+  libaom0
+  libargon2-1
+  libass9
+  libc-client2007e
+  libc6-dev
+  libcairo2
+  libcroco3
+  libcurl4
+  libdatrie1
+  libev4
+  libevent-2.1-7
+  libevent-core-2.1-7
+  libevent-extra-2.1-7
+  libevent-openssl-2.1-7
+  libevent-pthreads-2.1-7
+  libexif12
+  libfreetype6
+  libfribidi0
+  libgd3
+  libgdk-pixbuf2.0-0
+  libgdk-pixbuf2.0-common
+  libgnutls-openssl27
+  libgnutls30
+  libgnutlsxx28
+  libgraphite2-3
+  libgraphite2-3
+  libgs9
+  libharfbuzz-gobject0
+  libharfbuzz-icu0
+  libharfbuzz0b
+  liblzf1
+  libmagickcore-6.q16-3-extra
+  libmcrypt4
+  libmemcached11
+  libmp3lame0
+  libmysqlclient21
+  libnuma1
+  libogg0
+  libonig5
+  libopencore-amrnb0
+  libopencore-amrwb0
+  libopus0
+  libpango-1.0-0
+  libpangocairo-1.0-0
+  libpangoft2-1.0-0
+  libpixman-1-0
+  librabbitmq4
+  librsvg2-2
+  librsvg2-common
+  libsasl2-modules
+  libseccomp2
+  libsodium23
+  libspeex1
+  libthai-data
+  libthai0
+  libtheora0
+  libunistring2
+  libuv1
+  libvips42
+  libvorbis0a
+  libvorbisenc2
+  libvorbisfile3
+  libvpx6
+  libwebp6
+  libwebpdemux2
+  libwebpmux3
+  libx264-155
+  libx265-179
+  libxcb-render0
+  libxcb-shm0
+  libxrender1
+  libxslt1.1
+  libzip5
+  libzstd1
+  locales
+  lsb-release
+  make
+  netcat-openbsd
+  openssh-client
+  openssh-server
+  patch
+  poppler-utils
+  postgresql-client-15
+  python-is-python3
+  python3
+  rename
+  rsync
+  ruby
+  shared-mime-info
+  socat
+  stunnel
+  syslinux
+  tar
+  telnet
+  tzdata
+  unzip
+  wget
+  xz-utils
+  zip
+  zlib1g
+  zstd
+)
+
+apt-get install -y --no-install-recommends "${packages[@]}"
 
 cp /build/imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
 

--- a/heroku-22-build/setup.sh
+++ b/heroku-22-build/setup.sh
@@ -1,91 +1,90 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
-# Redirect stderr to stdout since tracing/apt-get/dpkg spam it for things that aren't errors.
-exec 2>&1
-set -x
+set -euxo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
+packages=(
+  autoconf
+  automake
+  bison
+  build-essential
+  bzr
+  cmake
+  gettext
+  git
+  jq
+  libacl1-dev
+  libapt-pkg-dev
+  libargon2-dev
+  libattr1-dev
+  libaudit-dev
+  libbsd-dev
+  libbz2-dev
+  libc-client2007e-dev
+  libcairo2-dev
+  libcap-dev
+  libcurl4-openssl-dev
+  libdb-dev
+  libev-dev
+  libevent-dev
+  libexif-dev
+  libffi-dev
+  libgcrypt20-dev
+  libgd-dev
+  libgdbm-dev
+  libgeoip-dev
+  libglib2.0-dev
+  libgnutls28-dev
+  libgs-dev
+  libheif-dev
+  libicu-dev
+  libidn11-dev
+  libjpeg-dev
+  libkeyutils-dev
+  libkmod-dev
+  libkrb5-dev
+  libldap2-dev
+  liblz4-dev
+  liblzf-dev
+  libmagic-dev
+  libmagickwand-dev
+  libmcrypt-dev
+  libmemcached-dev
+  libmysqlclient-dev
+  libncurses5-dev
+  libncursesw5-dev
+  libnetpbm10-dev
+  libonig-dev
+  libpam0g-dev
+  libpopt-dev
+  libpq-dev
+  librabbitmq-dev
+  libreadline-dev
+  librtmp-dev
+  libseccomp-dev
+  libselinux1-dev
+  libsemanage-dev
+  libsodium-dev
+  libssl-dev
+  libsystemd-dev
+  libtool
+  libudev-dev
+  libuv1-dev
+  libwrap0-dev
+  libxml2-dev
+  libxslt-dev
+  libyaml-dev
+  libzip-dev
+  libzstd-dev
+  mercurial
+  patchelf
+  python3-dev
+  zlib1g-dev
+)
+
 apt-get update --error-on=any
-apt-get install -y --no-install-recommends \
-    autoconf \
-    automake \
-    bison \
-    build-essential \
-    bzr \
-    cmake \
-    gettext \
-    git \
-    jq \
-    libacl1-dev \
-    libapt-pkg-dev \
-    libargon2-dev \
-    libattr1-dev \
-    libaudit-dev \
-    libbsd-dev \
-    libbz2-dev \
-    libc-client2007e-dev \
-    libcairo2-dev \
-    libcap-dev \
-    libcurl4-openssl-dev \
-    libdb-dev \
-    libev-dev \
-    libevent-dev \
-    libexif-dev \
-    libffi-dev \
-    libgcrypt20-dev \
-    libgd-dev \
-    libgdbm-dev \
-    libgeoip-dev \
-    libglib2.0-dev \
-    libgnutls28-dev \
-    libgs-dev \
-    libheif-dev \
-    libicu-dev \
-    libidn11-dev \
-    libjpeg-dev \
-    libkeyutils-dev \
-    libkmod-dev \
-    libkrb5-dev \
-    libldap2-dev \
-    liblz4-dev \
-    liblzf-dev \
-    libmagic-dev \
-    libmagickwand-dev \
-    libmcrypt-dev \
-    libmemcached-dev \
-    libmysqlclient-dev \
-    libncurses5-dev \
-    libncursesw5-dev \
-    libnetpbm10-dev \
-    libonig-dev \
-    libpam0g-dev \
-    libpopt-dev \
-    libpq-dev \
-    librabbitmq-dev \
-    libreadline-dev \
-    librtmp-dev \
-    libseccomp-dev \
-    libselinux1-dev \
-    libsemanage-dev \
-    libsodium-dev \
-    libssl-dev \
-    libsystemd-dev \
-    libtool \
-    libudev-dev \
-    libuv1-dev \
-    libwrap0-dev \
-    libxml2-dev \
-    libxslt-dev \
-    libyaml-dev \
-    libzip-dev \
-    libzstd-dev \
-    mercurial \
-    patchelf \
-    python3-dev \
-    zlib1g-dev \
+apt-get install -y --no-install-recommends "${packages[@]}"
 
 rm -rf /root/*
 rm -rf /tmp/*

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
-# Redirect stderr to stdout since tracing/apt-get/dpkg spam it for things that aren't errors.
-exec 2>&1
-set -x
+set -euxo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -30,132 +26,136 @@ apt-key add /build/postgresql-ACCC4CF8.asc
 
 apt-get update --error-on=any
 apt-get upgrade -y
-apt-get install -y --no-install-recommends \
-    apt-transport-https \
-    apt-utils \
-    bind9-host \
-    bzip2 \
-    coreutils \
-    curl \
-    dnsutils \
-    ed \
-    file \
-    fontconfig \
-    gcc \
-    geoip-database \
-    gettext-base \
-    ghostscript \
-    gir1.2-harfbuzz-0.0 \
-    git \
-    gsfonts \
-    imagemagick \
-    iproute2 \
-    iputils-tracepath \
-    language-pack-en \
-    less \
-    libaom3 \
-    libargon2-1 \
-    libass9 \
-    libc-client2007e \
-    libc6-dev \
-    libcairo2 \
-    libcurl4 \
-    libdatrie1 \
-    libdav1d5 \
-    libev4 \
-    libevent-2.1-7 \
-    libevent-core-2.1-7 \
-    libevent-extra-2.1-7 \
-    libevent-openssl-2.1-7 \
-    libevent-pthreads-2.1-7 \
-    libexif12 \
-    libfreetype6 \
-    libfribidi0 \
-    libgd3 \
-    libgdk-pixbuf2.0-0 \
-    libgdk-pixbuf2.0-common \
-    libgnutls-openssl27 \
-    libgnutls30 \
-    libgnutlsxx28 \
-    libgraphite2-3 \
-    libgraphite2-3 \
-    libgs9 \
-    libharfbuzz-gobject0 \
-    libharfbuzz-icu0 \
-    libharfbuzz0b \
-    libheif1 \
-    liblzf1 \
-    libmagickcore-6.q16-3-extra \
-    libmcrypt4 \
-    libmemcached11 \
-    libmp3lame0 \
-    libmysqlclient21 \
-    libnuma1 \
-    libogg0 \
-    libonig5 \
-    libopencore-amrnb0 \
-    libopencore-amrwb0 \
-    libopus0 \
-    libpango-1.0-0 \
-    libpangocairo-1.0-0 \
-    libpangoft2-1.0-0 \
-    libpixman-1-0 \
-    librabbitmq4 \
-    librsvg2-2 \
-    librsvg2-common \
-    libsasl2-modules \
-    libseccomp2 \
-    libsodium23 \
-    libspeex1 \
-    libsvtav1enc0 \
-    libthai-data \
-    libthai0 \
-    libtheora0 \
-    libunistring2 \
-    libuv1 \
-    libvips42 \
-    libvorbis0a \
-    libvorbisenc2 \
-    libvorbisfile3 \
-    libvpx7 \
-    libwebp7 \
-    libwebpdemux2 \
-    libwebpmux3 \
-    libx264-163 \
-    libx265-199 \
-    libxcb-render0 \
-    libxcb-shm0 \
-    libxrender1 \
-    libxslt1.1 \
-    libyaml-0-2 \
-    libzip4 \
-    libzstd1 \
-    locales \
-    lsb-release \
-    make \
-    netcat-openbsd \
-    openssh-client \
-    openssh-server \
-    patch \
-    poppler-utils \
-    postgresql-client-15 \
-    python-is-python3 \
-    python3 \
-    rename \
-    rsync \
-    shared-mime-info \
-    socat \
-    stunnel \
-    syslinux \
-    tar \
-    telnet \
-    tzdata \
-    unzip \
-    wget \
-    xz-utils \
-    zip \
-    zlib1g \
-    zstd \
+
+packages=(
+  apt-transport-https
+  apt-utils
+  bind9-host
+  bzip2
+  coreutils
+  curl
+  dnsutils
+  ed
+  file
+  fontconfig
+  gcc
+  geoip-database
+  gettext-base
+  ghostscript
+  gir1.2-harfbuzz-0.0
+  git
+  gsfonts
+  imagemagick
+  iproute2
+  iputils-tracepath
+  language-pack-en
+  less
+  libaom3
+  libargon2-1
+  libass9
+  libc-client2007e
+  libc6-dev
+  libcairo2
+  libcurl4
+  libdatrie1
+  libdav1d5
+  libev4
+  libevent-2.1-7
+  libevent-core-2.1-7
+  libevent-extra-2.1-7
+  libevent-openssl-2.1-7
+  libevent-pthreads-2.1-7
+  libexif12
+  libfreetype6
+  libfribidi0
+  libgd3
+  libgdk-pixbuf2.0-0
+  libgdk-pixbuf2.0-common
+  libgnutls-openssl27
+  libgnutls30
+  libgnutlsxx28
+  libgraphite2-3
+  libgraphite2-3
+  libgs9
+  libharfbuzz-gobject0
+  libharfbuzz-icu0
+  libharfbuzz0b
+  libheif1
+  liblzf1
+  libmagickcore-6.q16-3-extra
+  libmcrypt4
+  libmemcached11
+  libmp3lame0
+  libmysqlclient21
+  libnuma1
+  libogg0
+  libonig5
+  libopencore-amrnb0
+  libopencore-amrwb0
+  libopus0
+  libpango-1.0-0
+  libpangocairo-1.0-0
+  libpangoft2-1.0-0
+  libpixman-1-0
+  librabbitmq4
+  librsvg2-2
+  librsvg2-common
+  libsasl2-modules
+  libseccomp2
+  libsodium23
+  libspeex1
+  libsvtav1enc0
+  libthai-data
+  libthai0
+  libtheora0
+  libunistring2
+  libuv1
+  libvips42
+  libvorbis0a
+  libvorbisenc2
+  libvorbisfile3
+  libvpx7
+  libwebp7
+  libwebpdemux2
+  libwebpmux3
+  libx264-163
+  libx265-199
+  libxcb-render0
+  libxcb-shm0
+  libxrender1
+  libxslt1.1
+  libyaml-0-2
+  libzip4
+  libzstd1
+  locales
+  lsb-release
+  make
+  netcat-openbsd
+  openssh-client
+  openssh-server
+  patch
+  poppler-utils
+  postgresql-client-15
+  python-is-python3
+  python3
+  rename
+  rsync
+  shared-mime-info
+  socat
+  stunnel
+  syslinux
+  tar
+  telnet
+  tzdata
+  unzip
+  wget
+  xz-utils
+  zip
+  zlib1g
+  zstd
+)
+
+apt-get install -y --no-install-recommends "${packages[@]}"
 
 cp /build/imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
 

--- a/heroku-24-build/setup.sh
+++ b/heroku-24-build/setup.sh
@@ -1,87 +1,86 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
-# Redirect stderr to stdout since tracing/apt-get/dpkg spam it for things that aren't errors.
-exec 2>&1
-set -x
+set -euxo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
+packages=(
+  autoconf
+  automake
+  bison
+  build-essential
+  cmake
+  gettext
+  git
+  jq
+  libacl1-dev
+  libapt-pkg-dev
+  libargon2-dev
+  libattr1-dev
+  libaudit-dev
+  libbsd-dev
+  libbz2-dev
+  libc-client2007e-dev
+  libcairo2-dev
+  libcap-dev
+  libcurl4-openssl-dev
+  libdb-dev
+  libev-dev
+  libevent-dev
+  libexif-dev
+  libffi-dev
+  libgcrypt20-dev
+  libgd-dev
+  libgdbm-dev
+  libgeoip-dev
+  libglib2.0-dev
+  libgnutls28-dev
+  libheif-dev
+  libicu-dev
+  libidn11-dev
+  libjpeg-dev
+  libkeyutils-dev
+  libkmod-dev
+  libkrb5-dev
+  libldap2-dev
+  liblz4-dev
+  liblzf-dev
+  libmagic-dev
+  libmagickwand-dev
+  libmcrypt-dev
+  libmemcached-dev
+  libmysqlclient-dev
+  libncurses5-dev
+  libncursesw5-dev
+  libnetpbm10-dev
+  libonig-dev
+  libpam0g-dev
+  libpopt-dev
+  libpq-dev
+  librabbitmq-dev
+  libreadline-dev
+  librtmp-dev
+  libseccomp-dev
+  libselinux1-dev
+  libsemanage-dev
+  libsodium-dev
+  libssl-dev
+  libsystemd-dev
+  libtool
+  libudev-dev
+  libuv1-dev
+  libwrap0-dev
+  libxml2-dev
+  libxslt-dev
+  libyaml-dev
+  libzip-dev
+  libzstd-dev
+  patchelf
+  zlib1g-dev
+)
+
 apt-get update --error-on=any
-apt-get install -y --no-install-recommends \
-    autoconf \
-    automake \
-    bison \
-    build-essential \
-    cmake \
-    gettext \
-    git \
-    jq \
-    libacl1-dev \
-    libapt-pkg-dev \
-    libargon2-dev \
-    libattr1-dev \
-    libaudit-dev \
-    libbsd-dev \
-    libbz2-dev \
-    libc-client2007e-dev \
-    libcairo2-dev \
-    libcap-dev \
-    libcurl4-openssl-dev \
-    libdb-dev \
-    libev-dev \
-    libevent-dev \
-    libexif-dev \
-    libffi-dev \
-    libgcrypt20-dev \
-    libgd-dev \
-    libgdbm-dev \
-    libgeoip-dev \
-    libglib2.0-dev \
-    libgnutls28-dev \
-    libheif-dev \
-    libicu-dev \
-    libidn11-dev \
-    libjpeg-dev \
-    libkeyutils-dev \
-    libkmod-dev \
-    libkrb5-dev \
-    libldap2-dev \
-    liblz4-dev \
-    liblzf-dev \
-    libmagic-dev \
-    libmagickwand-dev \
-    libmcrypt-dev \
-    libmemcached-dev \
-    libmysqlclient-dev \
-    libncurses5-dev \
-    libncursesw5-dev \
-    libnetpbm10-dev \
-    libonig-dev \
-    libpam0g-dev \
-    libpopt-dev \
-    libpq-dev \
-    librabbitmq-dev \
-    libreadline-dev \
-    librtmp-dev \
-    libseccomp-dev \
-    libselinux1-dev \
-    libsemanage-dev \
-    libsodium-dev \
-    libssl-dev \
-    libsystemd-dev \
-    libtool \
-    libudev-dev \
-    libuv1-dev \
-    libwrap0-dev \
-    libxml2-dev \
-    libxslt-dev \
-    libyaml-dev \
-    libzip-dev \
-    libzstd-dev \
-    patchelf \
-    zlib1g-dev \
+apt-get install -y --no-install-recommends "${packages[@]}"
 
 rm -rf /root/*
 rm -rf /tmp/*

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
-# Redirect stderr to stdout since tracing/apt-get/dpkg spam it for things that aren't errors.
-exec 2>&1
-set -x
+set -euxo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -55,126 +51,130 @@ apt-key add /build/postgresql-ACCC4CF8.asc
 
 apt-get update --error-on=any
 apt-get upgrade -y --no-install-recommends
-apt-get install -y --no-install-recommends \
-    apt-transport-https \
-    apt-utils \
-    bind9-host \
-    bzip2 \
-    coreutils \
-    curl \
-    dnsutils \
-    ed \
-    file \
-    fontconfig \
-    gcc \
-    geoip-database \
-    gettext-base \
-    gir1.2-harfbuzz-0.0 \
-    git \
-    imagemagick \
-    iproute2 \
-    iputils-tracepath \
-    less \
-    libaom3 \
-    libargon2-1 \
-    libass9 \
-    libc-client2007e \
-    libc6-dev \
-    libcairo2 \
-    libcurl4 \
-    libdatrie1 \
-    libdav1d7 \
-    libev4 \
-    libevent-2.1-7 \
-    libevent-core-2.1-7 \
-    libevent-extra-2.1-7 \
-    libevent-openssl-2.1-7 \
-    libevent-pthreads-2.1-7 \
-    libexif12 \
-    libfreetype6 \
-    libfribidi0 \
-    libgd3 \
-    libgdk-pixbuf2.0-0 \
-    libgdk-pixbuf2.0-common \
-    libgnutls-openssl27 \
-    libgnutls30 \
-    libgraphite2-3 \
-    libgraphite2-3 \
-    libharfbuzz-gobject0 \
-    libharfbuzz-icu0 \
-    libharfbuzz0b \
-    libheif1 \
-    liblzf1 \
-    libmagickcore-6.q16-7-extra \
-    libmcrypt4 \
-    libmemcached11 \
-    libmp3lame0 \
-    libmysqlclient21 \
-    libnuma1 \
-    libogg0 \
-    libonig5 \
-    libopencore-amrnb0 \
-    libopencore-amrwb0 \
-    libopus0 \
-    libpango-1.0-0 \
-    libpangocairo-1.0-0 \
-    libpangoft2-1.0-0 \
-    libpixman-1-0 \
-    librabbitmq4 \
-    librsvg2-2 \
-    librsvg2-common \
-    libsasl2-modules \
-    libseccomp2 \
-    libsodium23 \
-    libspeex1 \
-    libsvtav1enc1d1 \
-    libthai-data \
-    libthai0 \
-    libtheora0 \
-    libunistring5 \
-    libuv1 \
-    libvips42 \
-    libvorbis0a \
-    libvorbisenc2 \
-    libvorbisfile3 \
-    libvpx8 \
-    libwebp7 \
-    libwebpdemux2 \
-    libwebpmux3 \
-    libx264-164 \
-    libx265-199 \
-    libxcb-render0 \
-    libxcb-shm0 \
-    libxrender1 \
-    libxslt1.1 \
-    libyaml-0-2 \
-    libzip4 \
-    libzstd1 \
-    locales \
-    lsb-release \
-    make \
-    netcat-openbsd \
-    openssh-client \
-    openssh-server \
-    patch \
-    poppler-utils \
-    postgresql-client-16 \
-    python-is-python3 \
-    python3 \
-    rename \
-    rsync \
-    shared-mime-info \
-    socat \
-    stunnel \
-    tar \
-    telnet \
-    tzdata \
-    unzip \
-    wget \
-    xz-utils \
-    zip \
-    zlib1g \
-    zstd \
+
+packages=(
+  apt-transport-https
+  apt-utils
+  bind9-host
+  bzip2
+  coreutils
+  curl
+  dnsutils
+  ed
+  file
+  fontconfig
+  gcc
+  geoip-database
+  gettext-base
+  gir1.2-harfbuzz-0.0
+  git
+  imagemagick
+  iproute2
+  iputils-tracepath
+  less
+  libaom3
+  libargon2-1
+  libass9
+  libc-client2007e
+  libc6-dev
+  libcairo2
+  libcurl4
+  libdatrie1
+  libdav1d7
+  libev4
+  libevent-2.1-7
+  libevent-core-2.1-7
+  libevent-extra-2.1-7
+  libevent-openssl-2.1-7
+  libevent-pthreads-2.1-7
+  libexif12
+  libfreetype6
+  libfribidi0
+  libgd3
+  libgdk-pixbuf2.0-0
+  libgdk-pixbuf2.0-common
+  libgnutls-openssl27
+  libgnutls30
+  libgraphite2-3
+  libgraphite2-3
+  libharfbuzz-gobject0
+  libharfbuzz-icu0
+  libharfbuzz0b
+  libheif1
+  liblzf1
+  libmagickcore-6.q16-7-extra
+  libmcrypt4
+  libmemcached11
+  libmp3lame0
+  libmysqlclient21
+  libnuma1
+  libogg0
+  libonig5
+  libopencore-amrnb0
+  libopencore-amrwb0
+  libopus0
+  libpango-1.0-0
+  libpangocairo-1.0-0
+  libpangoft2-1.0-0
+  libpixman-1-0
+  librabbitmq4
+  librsvg2-2
+  librsvg2-common
+  libsasl2-modules
+  libseccomp2
+  libsodium23
+  libspeex1
+  libsvtav1enc1d1
+  libthai-data
+  libthai0
+  libtheora0
+  libunistring5
+  libuv1
+  libvips42
+  libvorbis0a
+  libvorbisenc2
+  libvorbisfile3
+  libvpx8
+  libwebp7
+  libwebpdemux2
+  libwebpmux3
+  libx264-164
+  libx265-199
+  libxcb-render0
+  libxcb-shm0
+  libxrender1
+  libxslt1.1
+  libyaml-0-2
+  libzip4
+  libzstd1
+  locales
+  lsb-release
+  make
+  netcat-openbsd
+  openssh-client
+  openssh-server
+  patch
+  poppler-utils
+  postgresql-client-16
+  python-is-python3
+  python3
+  rename
+  rsync
+  shared-mime-info
+  socat
+  stunnel
+  tar
+  telnet
+  tzdata
+  unzip
+  wget
+  xz-utils
+  zip
+  zlib1g
+  zstd
+)
+
+apt-get install -y --no-install-recommends "${packages[@]}"
 
 # Generate locale data for "en_US", which is not available by default. Ubuntu
 # ships only with "C" and "POSIX" locales.


### PR DESCRIPTION
* Removes the stderr redirection to stdout, since it's no longer necessary (we're no longer using Travis CI, where stderr was highlighted in bright red)
* Combines the `set` calls
* Switches to an array for the list of packages to install, which avoids the need for line continuation markers, and will allow us to add code comments later explaining why we install certain packages (comments break lines using continuation markers)