### PR TITLE
Heroku-24: Stop using deprecated `apt-key add`

### DIFF
--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -38,16 +38,21 @@ EOF
 
 apt-get update --error-on=any
 
-# Required by apt-key and does not exist in the base image on newer Ubuntu.
-apt-get install -y --no-install-recommends gnupg
+# We have to install certificates first, so that APT can use HTTPS for apt.postgresql.org.
+apt-get install -y --no-install-recommends ca-certificates
 
 # In order to support all features offered by Heroku Postgres, we need newer postgresql-client
 # than is available in the Ubuntu repository, so use the upstream APT repository instead:
 # https://wiki.postgresql.org/wiki/Apt
-cat >>/etc/apt/sources.list <<EOF
-deb http://apt.postgresql.org/pub/repos/apt/ noble-pgdg main
+cat >/etc/apt/sources.list.d/pgdg.sources <<'EOF'
+Types: deb
+URIs: https://apt.postgresql.org/pub/repos/apt
+Suites: noble-pgdg
+Components: main
+Signed-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
 EOF
-apt-key add /build/postgresql-ACCC4CF8.asc
+mkdir -p /usr/share/postgresql-common/pgdg/
+cp /build/postgresql-ACCC4CF8.asc /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
 
 apt-get update --error-on=any
 apt-get upgrade -y --no-install-recommends
@@ -68,6 +73,7 @@ packages=(
   gettext-base
   gir1.2-harfbuzz-0.0
   git
+  gnupg
   imagemagick
   iproute2
   iputils-tracepath


### PR DESCRIPTION
Switches to the new method for importing/specifying keys:
https://wiki.postgresql.org/wiki/Apt#Manual_Repository_Configuration

This improves security, since now instead of the Postgres key being allowed to sign any package (including those from Ubuntu's APT repo), it's only trusted for packages from `apt.postgresql.org`.

This resolves:

```
W: http://apt.postgresql.org/pub/repos/apt/dists/noble-pgdg/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```

We're also using the new `deb822` format, instead of the one-line format, see:
https://manpages.ubuntu.com/manpages/noble/man5/sources.list.5.html

Now that we're not using `apt-key add` the `gnupg` package no longer needs to be installed earlier than the other packages, so has been moved to the main package install step. We do need `ca-certificates` installed early however, so that `apt-get update` can pull the HTTPS Postgres source (whilst `apt.postgresql.org` supports HTTP too and signing makes HTTPS less important, HTTPS is what's now used in the upstream setup docs, so we've switched to using HTTPS).

Fixes #248.
GUS-W-15213125.