### PR TITLE
Test `.img` file generation in CI on PRs and `main` too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,5 @@ jobs:
       - name: Unpublish temp tags from this run
         run: bin/unpublish-tags.sh
         if: always()
-      - name: Convert docker image and release to Heroku staging
+      - name: Convert docker image and for Git tags release to Heroku staging
         run: bin/convert-and-publish-to-heroku.sh
-        if: success() && github.ref_type == 'tag'

--- a/tools/bin/capture-docker-stack
+++ b/tools/bin/capture-docker-stack
@@ -12,12 +12,6 @@ STACK_VERSION=$(echo "${STACK}" | cut -d '-' -f 2-)
 DOCKER_IMAGE=heroku/$STACK_NAME:$STACK_VERSION
 DOCKER_IMAGE_VERSION=$(docker inspect "${DOCKER_IMAGE}" | jq .[].Id | cut -d ':' -f 2 | cut -b 1-12)
 
-if [[ ${GITHUB_REF_TYPE} == 'tag' ]]; then
-    GIT_REF=${GITHUB_REF_NAME:?'Error: GITHUB_REF_NAME must be set!'}
-else
-    abort "Error: Cannot publish without a Git tag!"
-fi
-
 IMG_BASE=${STACK_NAME}64-$STACK_VERSION-$DOCKER_IMAGE_VERSION
 IMG=/tmp/$IMG_BASE.img
 IMG_MNT=/tmp/$IMG_BASE
@@ -47,12 +41,12 @@ display "SHA256ing and gzipping image"
 make-image-archive "${IMG}" "${IMG_SHA256}" |& indent
 cat "${IMG_SHA256}"
 
+display "Capture Package Versions"
+capture-package-versions "${DOCKER_IMAGE}" "${IMG_PKG_VERSIONS}"
+
 if update-manifest; then
-    display "Starting push at $(date)"
-    display "Capture Package Versions"
-    capture-package-versions "${DOCKER_IMAGE}" "${IMG_PKG_VERSIONS}"
     display "Uploading files"
-    upload-image "${IMG_GZ}" "${IMG_SHA256}" "${IMG_MANIFEST}" "${STACK}" "${DOCKER_IMAGE_VERSION}" "${IMG_PKG_VERSIONS}" "${GIT_REF}" |& indent
+    upload-image "${IMG_GZ}" "${IMG_SHA256}" "${IMG_MANIFEST}" "${STACK}" "${DOCKER_IMAGE_VERSION}" "${IMG_PKG_VERSIONS}" "${GITHUB_REF_NAME}" |& indent
 else
     display "Skipping image upload"
 fi

--- a/tools/bin/update-manifest
+++ b/tools/bin/update-manifest
@@ -2,5 +2,6 @@
 
 set -euo pipefail
 
+[[ "${GITHUB_REF_TYPE:-}" == 'tag' ]] || { echo "Skipping upload since GITHUB_REF_TYPE != 'tag'" && exit 1; }
 [[ -v MANIFEST_APP_URL ]] || { echo "Missing manifest app url" && exit 1; }
 [[ -v MANIFEST_APP_TOKEN ]] || { echo "Missing manifest app token" && exit 1; }


### PR DESCRIPTION
The base images are built as Docker images and on release, uploaded to Docker Hub. However, the Heroku platform currently doesn't use those images directly, instead using a custom `.img` file from S3.

Previously this `.img` file generation was only performed on release, meaning that the CI for PRs and on `main` wouldn't test that code-path, so we might not find out about breakage until time of release.

Now, the generation (but not S3 upload) is performed for PRs / `main` too.

This will allow us to more easily iterate on optimising the image generation in later PRs.

GUS-W-15244492.