### PR TITLE
Improve image tools local development workflow

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -46,19 +46,14 @@ of 4 images:
 We use GitHub Actions to build and release Heroku Base Images:
 
 * Any push to `main` will build the images and push the nightly Docker tag variants (such as `heroku/heroku:22-build.nightly`).
-* Any new Git tag will build the image and push the latest Docker tag (such as `heroku/heroku:22-build`), as well as a versioned tag (such as `heroku/heroku:22-build.v89`).
+* Any new Git tag will build the image and push the latest Docker tag (such as `heroku/heroku:22-build`),
+  as well as a versioned tag (such as `heroku/heroku:22-build.v123`). The Docker image will then also be
+  converted to a Heroku-specific `.img` format and uploaded to S3 for consumption by the runtime hosts.
 
-# Releasing Heroku Base Images Locally (Prime)
+# Generating `.img` format Base Images locally
 
-When building Heroku Base Images for release locally, you'll need a number of additional steps.
+To test the generation of the Heroku-specific `.img` file:
 
-NOTE: These steps do *not* apply to `*cnb*` images.
-
-    export DOCKER_DEFAULT_PLATFORM=linux/amd64
-    # Build the base image(s) as you would above
-    # …
-    docker build ./tools -t heroku/image-tools
-    # SET MANIFEST_APP_URL and MANIFEST_APP_TOKEN values, this is the app that controls the bucket for images and metadata about the images (Cheverny)
-    docker run -it --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -e "MANIFEST_APP_URL=$MANIFEST_APP_URL" -e "MANIFEST_APP_TOKEN=$MANIFEST_APP_TOKEN" heroku/image-tools STACK
-    # this will use your local docker image and convert it to a heroku base image
-    # it will then upload this image and the staging manifest via the MANIFEST_APP
+1. Build the Docker images for your chosen stack as normal above.
+2. `docker build --platform=linux/amd64 ./tools -t heroku-image-tools`
+3. `docker run -it --rm --platform=linux/amd64 --privileged -v /var/run/docker.sock:/var/run/docker.sock heroku-image-tools STACK` (where `STACK` is the full stack name like `heroku-22`)

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,12 +1,11 @@
 # This Docker image is used only for local testing and not by the CI-based releases.
-FROM ubuntu:20.04
+# See BUILD.md for usage instructions.
+FROM ubuntu:22.04
 
-RUN apt-get update
-RUN apt-get install docker.io -y
-RUN apt-get install jq -y
-RUN apt-get install curl -y
+RUN apt-get update --error-on=any \
+  && apt-get install -y --no-install-recommends docker.io jq curl
 
 COPY bin /usr/local/bin
 
 VOLUME ["/var/run/docker.sock"]
-ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
+ENTRYPOINT ["/usr/local/bin/convert-to-heroku-stack-image"]

--- a/tools/bin/capture-package-versions
+++ b/tools/bin/capture-package-versions
@@ -5,4 +5,4 @@ set -euo pipefail
 DOCKER_IMAGE=$1
 OUTPUT_FILE=$2
 
-docker run --rm "${DOCKER_IMAGE}" dpkg-query -W -f "\${package},\${version}\n" | jq -s -R -f /usr/local/bin/csv-to-array.jq > "${OUTPUT_FILE}"
+docker run --platform=linux/amd64 --rm "${DOCKER_IMAGE}" dpkg-query -W -f "\${package},\${version}\n" | jq -s -R -f /usr/local/bin/csv-to-array.jq > "${OUTPUT_FILE}"

--- a/tools/bin/convert-to-heroku-stack-image
+++ b/tools/bin/convert-to-heroku-stack-image
@@ -2,11 +2,15 @@
 
 set -euo pipefail
 
+STACK="${1:-}"
+
+[[ "${STACK}" =~ ^heroku-[0-9]+$ ]] || abort "fatal: invalid STACK"
+
 VERSION_PREFIX=$(date '+%Y%m%d-%H%M%S')
 
 while [ $# -gt 0 ]; do
-  capture-docker-stack "$1"       "$VERSION_PREFIX"
-  capture-docker-stack "$1-build" "$VERSION_PREFIX"
+  capture-docker-stack "${STACK}"       "$VERSION_PREFIX"
+  capture-docker-stack "${STACK}-build" "$VERSION_PREFIX"
   shift
 done
 

--- a/tools/bin/docker-entrypoint
+++ b/tools/bin/docker-entrypoint
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-convert-to-heroku-stack-image "$@"

--- a/tools/bin/export-docker-image
+++ b/tools/bin/export-docker-image
@@ -5,7 +5,7 @@ set -euo pipefail
 DOCKER_IMAGE="$1"
 MNT="$2"
 
-CONTAINER="$(docker create "$DOCKER_IMAGE")"
+CONTAINER="$(docker create --platform linux/amd64 "$DOCKER_IMAGE")"
 trap 'docker rm "$CONTAINER" > /dev/null' EXIT
 
 docker export "$CONTAINER" | tar -x -C "$MNT" --exclude=lib/modules bin etc lib lib64 sbin usr var/lib


### PR DESCRIPTION
The scripts under `tools/` are used for the conversion of Docker images to the Heroku-specific `.img` file format.

As of #261 we now test those in CI, however, there were still a few rough edges when using them locally (discovered whilst I'm working on fixing the `.img` sizing issue), which have been improved here.

GUS-W-15245136.