### PR TITLE
Misc image tool script improvements

### DIFF
--- a/tools/bin/capture-docker-stack
+++ b/tools/bin/capture-docker-stack
@@ -17,7 +17,7 @@ DOCKER_IMAGE_VERSION=$(docker inspect "${DOCKER_IMAGE}" | jq .[].Id | cut -d ':'
 # The `--user root` is required since the images for newer stacks default to a non-root user.
 DOCKER_IMAGE_SIZE_IN_MB=$(docker run --rm --platform linux/amd64 --user root "${DOCKER_IMAGE}" du -sx --block-size=M | cut -d 'M' -f 1)
 
-IMG_BASE=${STACK_NAME}64-$STACK_VERSION-$DOCKER_IMAGE_VERSION
+IMG_BASE=${STACK_NAME}-$STACK_VERSION-$DOCKER_IMAGE_VERSION
 IMG=/tmp/$IMG_BASE.img
 IMG_MNT=/tmp/$IMG_BASE
 IMG_GZ=/tmp/$IMG_BASE.img.gz

--- a/tools/bin/make-filesystem-image
+++ b/tools/bin/make-filesystem-image
@@ -21,5 +21,13 @@ mkdir -p "$(dirname "$IMG")"
 # https://unix.stackexchange.com/a/121888
 fallocate --length "${IMG_SIZE_IN_MB}MiB" "${IMG}"
 
+# Format that file as an ext3 filesystem.
+# The `-m` argument reduces reserved-blocks-percentage from its default of 5% to 1%.
+# TODO: Switch to calling `mkfs.ext3` or `mke2fs -t ext3` since the `mkfs` alias is deprecated:
+# https://manpages.ubuntu.com/manpages/jammy/en/man8/mkfs.8.html
 mkfs -t ext3 -m 1 "$IMG"
+
+# Adjust the filesystem parameters for improved performance on runtime instances.
+# The `-c` and `-i` arguments disable automatic filesystem checks, which are otherwise run based
+# on number of times the image is mounted, or how much time has passed since the last check.
 tune2fs -c 0 -i 0 "$IMG"


### PR DESCRIPTION
* Removes the redundant `64` suffix from the image filenames/mount directories on disk. This doesn't affect the filename on S3. 
* Adds comments to the `mkfs` / `tune2fs` usages, since their purpose and arguments are IMO not immediately obvious.

Docs for the related tools:
https://manpages.ubuntu.com/manpages/jammy/en/man8/mkfs.8.html
https://manpages.ubuntu.com/manpages/jammy/en/man8/tune2fs.8.html

Split out of #263.

GUS-W-15245261.