### PR TITLE
Add missing OCI image labels from CNB spec

### DIFF
--- a/heroku-20-cnb-build/Dockerfile
+++ b/heroku-20-cnb-build/Dockerfile
@@ -7,10 +7,19 @@ RUN groupadd heroku --gid 1000 && \
 RUN mkdir /app && \
   chown heroku:heroku /app
 
+# https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#build-image
 ENV CNB_USER_ID=1000
 ENV CNB_GROUP_ID=1000
-ENV CNB_STACK_ID "heroku-20"
+# Note: This image doesn't inherit from the CNB run image variant so we have
+# to redeclare the labels present in the CNB run image again here.
+LABEL io.buildpacks.base.distro.name="ubuntu"
+LABEL io.buildpacks.base.distro.version="20.04"
+LABEL io.buildpacks.base.homepage="https://github.com/heroku/base-images"
+LABEL io.buildpacks.base.maintainer="Heroku"
 
+# Stack IDs are deprecated, but we still set these for backwards compatibility:
+# https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#iobuildpacksstack-labels
+ENV CNB_STACK_ID "heroku-20"
 LABEL io.buildpacks.stack.id="heroku-20"
 
 USER heroku

--- a/heroku-20-cnb/Dockerfile
+++ b/heroku-20-cnb/Dockerfile
@@ -6,6 +6,15 @@ RUN ln -s /workspace /app
 RUN groupadd heroku --gid 1000 && \
   useradd heroku -u 1000 -g 1000 -s /bin/bash -m
 
-LABEL io.buildpacks.stack.id="heroku-20"
+# https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#run-image
 USER heroku
+LABEL io.buildpacks.base.distro.name="ubuntu"
+LABEL io.buildpacks.base.distro.version="20.04"
+LABEL io.buildpacks.base.homepage="https://github.com/heroku/base-images"
+LABEL io.buildpacks.base.maintainer="Heroku"
+
+# Stack IDs are deprecated, but we still set this for backwards compatibility:
+# https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#iobuildpacksstack-labels
+LABEL io.buildpacks.stack.id="heroku-20"
+
 ENV HOME /app

--- a/heroku-22-cnb-build/Dockerfile
+++ b/heroku-22-cnb-build/Dockerfile
@@ -7,10 +7,19 @@ RUN groupadd heroku --gid 1000 && \
 RUN mkdir /app && \
   chown heroku:heroku /app
 
+# https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#build-image
 ENV CNB_USER_ID=1000
 ENV CNB_GROUP_ID=1000
-ENV CNB_STACK_ID "heroku-22"
+# Note: This image doesn't inherit from the CNB run image variant so we have
+# to redeclare the labels present in the CNB run image again here.
+LABEL io.buildpacks.base.distro.name="ubuntu"
+LABEL io.buildpacks.base.distro.version="22.04"
+LABEL io.buildpacks.base.homepage="https://github.com/heroku/base-images"
+LABEL io.buildpacks.base.maintainer="Heroku"
 
+# Stack IDs are deprecated, but we still set these for backwards compatibility:
+# https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#iobuildpacksstack-labels
+ENV CNB_STACK_ID "heroku-22"
 LABEL io.buildpacks.stack.id="heroku-22"
 
 USER heroku

--- a/heroku-22-cnb/Dockerfile
+++ b/heroku-22-cnb/Dockerfile
@@ -6,6 +6,15 @@ RUN ln -s /workspace /app
 RUN groupadd heroku --gid 1000 && \
   useradd heroku -u 1000 -g 1000 -s /bin/bash -m
 
-LABEL io.buildpacks.stack.id="heroku-22"
+# https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#run-image
 USER heroku
+LABEL io.buildpacks.base.distro.name="ubuntu"
+LABEL io.buildpacks.base.distro.version="22.04"
+LABEL io.buildpacks.base.homepage="https://github.com/heroku/base-images"
+LABEL io.buildpacks.base.maintainer="Heroku"
+
+# Stack IDs are deprecated, but we still set this for backwards compatibility:
+# https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#iobuildpacksstack-labels
+LABEL io.buildpacks.stack.id="heroku-22"
+
 ENV HOME /app

--- a/heroku-24-build/Dockerfile
+++ b/heroku-24-build/Dockerfile
@@ -3,8 +3,12 @@ FROM $BASE_IMAGE
 USER root
 RUN --mount=target=/build /build/setup.sh
 
-# https://github.com/buildpacks/spec/blob/main/platform.md#build-image
+# https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#build-image
+# The `io.buildpacks.base.*` labels are inherited from the run image, so don't need to be repeated here.
 USER 1002
 ENV CNB_USER_ID=1002
 ENV CNB_GROUP_ID=1000
+
+# Stack IDs are deprecated, but we still set this for backwards compatibility:
+# https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#iobuildpacksstack-labels
 ENV CNB_STACK_ID "heroku-24"

--- a/heroku-24/Dockerfile
+++ b/heroku-24/Dockerfile
@@ -1,6 +1,13 @@
 FROM ubuntu:24.04
 RUN --mount=target=/build /build/setup.sh
 
-# https://github.com/buildpacks/spec/blob/main/platform.md#run-image
+# https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#run-image
 USER 1001
+LABEL io.buildpacks.base.distro.name="ubuntu"
+LABEL io.buildpacks.base.distro.version="24.04"
+LABEL io.buildpacks.base.homepage="https://github.com/heroku/base-images"
+LABEL io.buildpacks.base.maintainer="Heroku"
+
+# Stack IDs are deprecated, but we still set this for backwards compatibility:
+# https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#iobuildpacksstack-labels
 LABEL io.buildpacks.stack.id="heroku-24"


### PR DESCRIPTION
Adds the following labels:
- `io.buildpacks.base.distro.name`
- `io.buildpacks.base.distro.version`
- `io.buildpacks.base.homepage`
- `io.buildpacks.base.maintainer`

Of note, adding the `io.buildpacks.base.distro.*` labels unblocks buildpacks being able to determine the distro name/version from within detect/build, allowing our CNBs to migrate from stacks to targets, and thus to start using Buildpack API 0.10.

See:
https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#build-image
https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#run-image
https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#target-data

Fixes #249.
GUS-W-15213143.