### PR TITLE
Misc Dockerfile improvements

### DIFF
--- a/heroku-20-cnb-build/Dockerfile
+++ b/heroku-20-cnb-build/Dockerfile
@@ -1,11 +1,10 @@
 ARG BASE_IMAGE=heroku/heroku:20-build
 FROM $BASE_IMAGE
 
-RUN groupadd heroku --gid 1000 && \
-  useradd heroku -u 1000 -g 1000 -s /bin/bash -m
-
-RUN mkdir /app && \
-  chown heroku:heroku /app
+RUN groupadd heroku --gid 1000 \
+  && useradd heroku --uid 1000 --gid 1000 --shell /bin/bash --create-home \
+  && mkdir /app \
+  && chown heroku:heroku /app
 
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#build-image
 ENV CNB_USER_ID=1000
@@ -19,7 +18,7 @@ LABEL io.buildpacks.base.maintainer="Heroku"
 
 # Stack IDs are deprecated, but we still set these for backwards compatibility:
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#iobuildpacksstack-labels
-ENV CNB_STACK_ID "heroku-20"
+ENV CNB_STACK_ID="heroku-20"
 LABEL io.buildpacks.stack.id="heroku-20"
 
 USER heroku

--- a/heroku-20-cnb/Dockerfile
+++ b/heroku-20-cnb/Dockerfile
@@ -1,10 +1,9 @@
 ARG BASE_IMAGE=heroku/heroku:20
 FROM $BASE_IMAGE
 
-RUN ln -s /workspace /app
-
-RUN groupadd heroku --gid 1000 && \
-  useradd heroku -u 1000 -g 1000 -s /bin/bash -m
+RUN groupadd heroku --gid 1000 \
+  && useradd heroku --uid 1000 --gid 1000 --shell /bin/bash --create-home \
+  && ln -s /workspace /app
 
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#run-image
 USER heroku
@@ -17,4 +16,4 @@ LABEL io.buildpacks.base.maintainer="Heroku"
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#iobuildpacksstack-labels
 LABEL io.buildpacks.stack.id="heroku-20"
 
-ENV HOME /app
+ENV HOME=/app

--- a/heroku-22-cnb-build/Dockerfile
+++ b/heroku-22-cnb-build/Dockerfile
@@ -1,11 +1,10 @@
 ARG BASE_IMAGE=heroku/heroku:22-build
 FROM $BASE_IMAGE
 
-RUN groupadd heroku --gid 1000 && \
-  useradd heroku -u 1000 -g 1000 -s /bin/bash -m
-
-RUN mkdir /app && \
-  chown heroku:heroku /app
+RUN groupadd heroku --gid 1000 \
+  && useradd heroku --uid 1000 --gid 1000 --shell /bin/bash --create-home \
+  && mkdir /app \
+  && chown heroku:heroku /app
 
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#build-image
 ENV CNB_USER_ID=1000
@@ -19,7 +18,7 @@ LABEL io.buildpacks.base.maintainer="Heroku"
 
 # Stack IDs are deprecated, but we still set these for backwards compatibility:
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#iobuildpacksstack-labels
-ENV CNB_STACK_ID "heroku-22"
+ENV CNB_STACK_ID="heroku-22"
 LABEL io.buildpacks.stack.id="heroku-22"
 
 USER heroku

--- a/heroku-22-cnb/Dockerfile
+++ b/heroku-22-cnb/Dockerfile
@@ -1,10 +1,9 @@
 ARG BASE_IMAGE=heroku/heroku:22
 FROM $BASE_IMAGE
 
-RUN ln -s /workspace /app
-
-RUN groupadd heroku --gid 1000 && \
-  useradd heroku -u 1000 -g 1000 -s /bin/bash -m
+RUN groupadd heroku --gid 1000 \
+  && useradd heroku --uid 1000 --gid 1000 --shell /bin/bash --create-home \
+  && ln -s /workspace /app
 
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#run-image
 USER heroku
@@ -17,4 +16,4 @@ LABEL io.buildpacks.base.maintainer="Heroku"
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#iobuildpacksstack-labels
 LABEL io.buildpacks.stack.id="heroku-22"
 
-ENV HOME /app
+ENV HOME=/app

--- a/heroku-24-build/Dockerfile
+++ b/heroku-24-build/Dockerfile
@@ -1,5 +1,7 @@
 ARG BASE_IMAGE=heroku/heroku:24
 FROM $BASE_IMAGE
+
+# We have to temporarily switch back to root, since the run image sets a non-root default USER.
 USER root
 RUN --mount=target=/build /build/setup.sh
 
@@ -11,4 +13,4 @@ ENV CNB_GROUP_ID=1000
 
 # Stack IDs are deprecated, but we still set this for backwards compatibility:
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#iobuildpacksstack-labels
-ENV CNB_STACK_ID "heroku-24"
+ENV CNB_STACK_ID="heroku-24"

--- a/heroku-24/Dockerfile
+++ b/heroku-24/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:24.04
+
 RUN --mount=target=/build /build/setup.sh
 
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#run-image

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -197,8 +197,8 @@ apt-get purge -y openjdk-8-jre-headless
 apt-get autoremove -y --purge
 test "$(file -b /etc/ssl/certs/java/cacerts)" = "Java KeyStore"
 
-useradd heroku -u 1001 -g 1000 -s /bin/bash -m
-useradd heroku-build -u 1002 -g 1000 -s /bin/bash -m
+useradd heroku --uid 1001 --gid 1000 --shell /bin/bash --create-home
+useradd heroku-build --uid 1002 --gid 1000 --shell /bin/bash --create-home
 groupmod --new-name heroku ubuntu
 deluser --remove-home ubuntu
 


### PR DESCRIPTION
* Combines a few `RUN` statements to reduce number of image layers.
* Switches remaining `ENV` usages to the form that uses `=` for consistency and per recommendation here: https://docs.docker.com/reference/dockerfile/#env
* Uses long form CLI arguments for [`useradd`](https://manpages.ubuntu.com/manpages/jammy/en/man8/useradd.8.html) to make their purpose clearer.

Noticed whilst working on #265.

 GUS-W-15213143.