### PR TITLE
Skip running the "unpublish temp tags" step in CI for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,6 @@ jobs:
         if: success() && (github.ref_name == 'main' || github.ref_type == 'tag')
       - name: Unpublish temp tags from this run
         run: bin/unpublish-tags.sh
-        if: always()
+        if: always() && (github.ref_name == 'main' || github.ref_type == 'tag')
       - name: Convert docker image and for Git tags release to Heroku staging
         run: bin/convert-and-publish-to-heroku.sh


### PR DESCRIPTION
Currently the "unpublish temp tags" GitHub Actions step is always run, even if no tags were generated that run (such as for PRs, where we don't publish anything).

Whilst this doesn't cause any harm normally, when contributors open a PR from a fork, the "unpublish temp tags" will fail since it doesn't have access to the secrets required to perform the (redundant) unpublish.

As such, the step now uses the same `if` ref-related conditionals that the publish step itself uses (so we only try to unpublish if this was a job type that publishes something).

This fixes the failures seen in #269:
https://github.com/heroku/base-images/actions/runs/8351455845/job/22859813877?pr=269

GUS-W-15292389.