### PR TITLE
Always use the `default` usage type with `mkfs`

### DIFF
--- a/tools/bin/make-filesystem-image
+++ b/tools/bin/make-filesystem-image
@@ -13,6 +13,8 @@ DOCKER_IMAGE_SIZE_IN_MB="$2"
 # as to ensure a few MB additional free space headroom.
 IMG_SIZE_IN_MB=$((DOCKER_IMAGE_SIZE_IN_MB * 107 / 100))
 
+echo "Using file size of ${IMG_SIZE_IN_MB} MB based on Docker image size of ${DOCKER_IMAGE_SIZE_IN_MB} MB"
+
 mkdir -p "$(dirname "$IMG")"
 
 # Create an empty file of the specified size.
@@ -22,10 +24,12 @@ mkdir -p "$(dirname "$IMG")"
 fallocate --length "${IMG_SIZE_IN_MB}MiB" "${IMG}"
 
 # Format that file as an ext3 filesystem.
+# The `-T` argument forces the 'default' config profile to be used, since otherwise if the filesystem size
+# is less than 512 MB (as is the case for Heroku-24's run image) the 'small' profile would be used instead.
 # The `-m` argument reduces reserved-blocks-percentage from its default of 5% to 1%.
 # TODO: Switch to calling `mkfs.ext3` or `mke2fs -t ext3` since the `mkfs` alias is deprecated:
 # https://manpages.ubuntu.com/manpages/jammy/en/man8/mkfs.8.html
-mkfs -t ext3 -m 1 "$IMG"
+mkfs -t ext3 -T default -m 1 -v "$IMG"
 
 # Adjust the filesystem parameters for improved performance on runtime instances.
 # The `-c` and `-i` arguments disable automatic filesystem checks, which are otherwise run based


### PR DESCRIPTION
When creating an `ext3` filesystem with `mkfs` (which underneath calls `mke2fs` via the `mke2fs` alias) various default filesystem settings (such as the inode ratio and block size) are chosen based on the "usage type" of the filesystem.

If not explicitly specified, this "usage type" is determined based on the size of the filesystem. For example, the `default` profile is used
 for filesystems between 512 MB and 4 TB, and the `small` profile is
 used for filesystems between 3 MB and 512 MB.

See:
https://manpages.ubuntu.com/manpages/jammy/en/man8/mkfs.ext3.8.html

For #266 I have several local changes for making the Heroku-24 images smaller, however, image generation was failing since the slimmer images now fall under the 512 MB threshold, causing `mke2fs` to use the `small` profile instead. This `small` profile uses a drastically different `inode_ratio`, which is very inefficient for our use-case - resulting in a filesystem overhead of over 11%, which throws off the `.img` size calculation.

Whilst we could work around this by adjusting the `.img` size calculations, it makes more sense to force the usage of the `default` profile, so all of our base images use the same filesystem settings, rather than relying on `mke2fs`'s size heuristics.

I've also enabled verbose output (which shows the profile being used) and added additional file size logging.

GUS-W-15292800.