### PR TITLE
Heroku-24: Remove git from the run image

### DIFF
--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -37,8 +37,6 @@ gettext-base
 gir1.2-freedesktop
 gir1.2-glib-2.0
 gir1.2-harfbuzz-0.0
-git
-git-man
 gnupg
 gnupg-utils
 gpg
@@ -103,7 +101,6 @@ libdjvulibre-text
 libdjvulibre21
 libedit2
 libelf1
-liberror-perl
 libev4
 libevent-2.1-7
 libevent-core-2.1-7

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -37,8 +37,6 @@ gettext-base
 gir1.2-freedesktop
 gir1.2-glib-2.0
 gir1.2-harfbuzz-0.0
-git
-git-man
 gnupg
 gnupg-utils
 gpg
@@ -103,7 +101,6 @@ libdjvulibre-text
 libdjvulibre21
 libedit2
 libelf1
-liberror-perl
 libev4
 libevent-2.1-7
 libevent-core-2.1-7

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -71,7 +71,6 @@ packages=(
   geoip-database
   gettext-base
   gir1.2-harfbuzz-0.0
-  git
   gnupg
   imagemagick
   iproute2


### PR DESCRIPTION
(This is stacked on top of #273.)

Since:
- Most Git use-cases are for cloning dependencies during the build (and Git will still be in the build image).
- On Heroku at runtime there is no `.git/` metadata to query the local project's repo anyway (since the directory isn't preserved during the build).
- It reduces the run image size by 17 MB, and in a CNB world image size is a much bigger concern, so we need to be more selective about what packages we include.
- Once Heroku-24 GAs we can't remove packages (since it will break backwards compatibility given stack rebasing), however, we can add packages - so we should err on the side of trying out removing packages now.

Before (once #273 merges):

```
-----> Size breakdown...
       heroku/heroku:24         458MB
       heroku/heroku:24-build   1.13GB
```

After:

```
-----> Size breakdown...
       heroku/heroku:24         441MB  (17 MB reduction)
       heroku/heroku:24-build   1.13GB (unchanged)
```

Towards #266.
GUS-W-15159536.