### PR TITLE
Heroku-24: Remove stunnel

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -95,7 +95,6 @@ libacl1-dev
 libaec0
 libaom-dev
 libaom3
-libapparmor1
 libapt-pkg-dev
 libapt-pkg6.0
 libarchive13
@@ -144,7 +143,6 @@ libcgif0
 libcom-err2
 libcrypt-dev
 libcrypt1
-libcryptsetup12
 libctf-nobfd0
 libctf0
 libcurl3-gnutls
@@ -161,7 +159,6 @@ libde265-dev
 libdebconfclient0
 libdeflate-dev
 libdeflate0
-libdevmapper1.02.1
 libdjvulibre-dev
 libdjvulibre-text
 libdjvulibre21
@@ -182,7 +179,6 @@ libexif12
 libexpat1
 libexpat1-dev
 libext2fs2
-libfdisk1
 libffi-dev
 libffi8
 libfftw3-double3
@@ -434,7 +430,6 @@ libstdc++-13-dev
 libstdc++6
 libsvtav1enc1d1
 libsystemd-dev
-libsystemd-shared
 libsystemd0
 libsz2
 libtasn1-6
@@ -566,9 +561,6 @@ sed
 sensible-utils
 shared-mime-info
 socat
-stunnel4
-systemd
-systemd-dev
 sysvinit-utils
 tar
 telnet

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -95,7 +95,6 @@ libacl1-dev
 libaec0
 libaom-dev
 libaom3
-libapparmor1
 libapt-pkg-dev
 libapt-pkg6.0
 libarchive13
@@ -144,7 +143,6 @@ libcgif0
 libcom-err2
 libcrypt-dev
 libcrypt1
-libcryptsetup12
 libctf-nobfd0
 libctf0
 libcurl3-gnutls
@@ -161,7 +159,6 @@ libde265-dev
 libdebconfclient0
 libdeflate-dev
 libdeflate0
-libdevmapper1.02.1
 libdjvulibre-dev
 libdjvulibre-text
 libdjvulibre21
@@ -182,7 +179,6 @@ libexif12
 libexpat1
 libexpat1-dev
 libext2fs2
-libfdisk1
 libffi-dev
 libffi8
 libfftw3-double3
@@ -433,7 +429,6 @@ libstdc++-13-dev
 libstdc++6
 libsvtav1enc1d1
 libsystemd-dev
-libsystemd-shared
 libsystemd0
 libsz2
 libtasn1-6
@@ -565,9 +560,6 @@ sed
 sensible-utils
 shared-mime-info
 socat
-stunnel4
-systemd
-systemd-dev
 sysvinit-utils
 tar
 telnet

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -60,7 +60,6 @@ less
 libacl1
 libaec0
 libaom3
-libapparmor1
 libapt-pkg6.0
 libarchive13
 libargon2-1
@@ -87,7 +86,6 @@ libcfitsio10
 libcgif0
 libcom-err2
 libcrypt1
-libcryptsetup12
 libcurl3-gnutls
 libcurl4
 libdatrie1
@@ -96,7 +94,6 @@ libdb5.3
 libde265-0
 libdebconfclient0
 libdeflate0
-libdevmapper1.02.1
 libdjvulibre-text
 libdjvulibre21
 libedit2
@@ -110,7 +107,6 @@ libevent-pthreads-2.1-7
 libexif12
 libexpat1
 libext2fs2
-libfdisk1
 libffi8
 libfftw3-double3
 libfido2-1
@@ -155,7 +151,6 @@ libjson-c5
 libjxl0.7
 libk5crypto3
 libkeyutils1
-libkmod2
 libkrb5-3
 libkrb5support0
 libksba8
@@ -244,7 +239,6 @@ libssh-4
 libssl3
 libstdc++6
 libsvtav1enc1d1
-libsystemd-shared
 libsystemd0
 libsz2
 libtasn1-6
@@ -328,9 +322,6 @@ sed
 sensible-utils
 shared-mime-info
 socat
-stunnel4
-systemd
-systemd-dev
 sysvinit-utils
 tar
 telnet

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -60,7 +60,6 @@ less
 libacl1
 libaec0
 libaom3
-libapparmor1
 libapt-pkg6.0
 libarchive13
 libargon2-1
@@ -87,7 +86,6 @@ libcfitsio10
 libcgif0
 libcom-err2
 libcrypt1
-libcryptsetup12
 libcurl3-gnutls
 libcurl4
 libdatrie1
@@ -96,7 +94,6 @@ libdb5.3
 libde265-0
 libdebconfclient0
 libdeflate0
-libdevmapper1.02.1
 libdjvulibre-text
 libdjvulibre21
 libedit2
@@ -110,7 +107,6 @@ libevent-pthreads-2.1-7
 libexif12
 libexpat1
 libext2fs2
-libfdisk1
 libffi8
 libfftw3-double3
 libfido2-1
@@ -155,7 +151,6 @@ libjson-c5
 libjxl0.7
 libk5crypto3
 libkeyutils1
-libkmod2
 libkrb5-3
 libkrb5support0
 libksba8
@@ -244,7 +239,6 @@ libssh-4
 libssl3
 libstdc++6
 libsvtav1enc1d1
-libsystemd-shared
 libsystemd0
 libsz2
 libtasn1-6
@@ -328,9 +322,6 @@ sed
 sensible-utils
 shared-mime-info
 socat
-stunnel4
-systemd
-systemd-dev
 sysvinit-utils
 tar
 telnet

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -164,7 +164,6 @@ packages=(
   rsync
   shared-mime-info
   socat
-  stunnel
   tar
   telnet
   tzdata


### PR DESCRIPTION
(This is stacked on top of #274.)

Since:
- `heroku-buildpack-pgbouncer` hasn't used stunnel since 2018: https://github.com/heroku/heroku-buildpack-pgbouncer/pull/104
- Redis 6 and newer support native TLS, making `heroku-buildpack-redis` redundant: https://github.com/heroku/heroku-buildpack-redis/pull/40 (The buildpack can be sunset once the last couple of old Redis instances are shut down)
- If any other less common use-case needs stunnel, they can install it using APT.
- It reduces the run and build image sizes by 17 MB, and in a CNB world image size is a much bigger concern, so we need to be more selective about what packages we include.
- Once Heroku-24 GAs we can't remove packages (since it will break backwards compatibility given stack rebasing), however, we can add packages - so we should err on the side of trying out removing packages now.

Before (once the other PRs are merged):

```
-----> Size breakdown...
       heroku/heroku:24         441MB
       heroku/heroku:24-build   1.13GB
```

After:

```
-----> Size breakdown...
       heroku/heroku:24         424MB  (17 MB reduction)
       heroku/heroku:24-build   1.11GB (17 MB reduction)
```

Towards #266.
GUS-W-15159536.