### PR TITLE
Heroku-24: Remove Python from the run image

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -542,7 +542,6 @@ poppler-utils
 postgresql-client-16
 postgresql-client-common
 procps
-python-is-python3
 python3
 python3-imath
 python3-minimal

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -541,7 +541,6 @@ poppler-utils
 postgresql-client-16
 postgresql-client-common
 procps
-python-is-python3
 python3
 python3-imath
 python3-minimal

--- a/heroku-24-build/setup.sh
+++ b/heroku-24-build/setup.sh
@@ -77,6 +77,9 @@ packages=(
   libzip-dev
   libzstd-dev
   patchelf
+  # Python is often needed during the build for non-Python apps, which aren't using the
+  # Python buildpack. e.g. Node.js packages that use node-gyp require Python during install.
+  python3
   zlib1g-dev
 )
 

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -211,9 +211,6 @@ libpopt0
 libpq5
 libproc2-0
 libpsl5
-libpython3-stdlib
-libpython3.12-minimal
-libpython3.12-stdlib
 librabbitmq4
 libraw23
 libreadline8
@@ -288,7 +285,6 @@ login
 logsave
 lsb-release
 mawk
-media-types
 mlock
 mount
 mysql-common
@@ -310,11 +306,6 @@ poppler-utils
 postgresql-client-16
 postgresql-client-common
 procps
-python-is-python3
-python3
-python3-minimal
-python3.12
-python3.12-minimal
 readline-common
 rename
 rsync

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -211,9 +211,6 @@ libpopt0
 libpq5
 libproc2-0
 libpsl5
-libpython3-stdlib
-libpython3.12-minimal
-libpython3.12-stdlib
 librabbitmq4
 libraw23
 libreadline8
@@ -288,7 +285,6 @@ login
 logsave
 lsb-release
 mawk
-media-types
 mlock
 mount
 mysql-common
@@ -310,11 +306,6 @@ poppler-utils
 postgresql-client-16
 postgresql-client-common
 procps
-python-is-python3
-python3
-python3-minimal
-python3.12
-python3.12-minimal
 readline-common
 rename
 rsync

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -158,8 +158,6 @@ packages=(
   patch
   poppler-utils
   postgresql-client-16
-  python-is-python3
-  python3
   rename
   rsync
   shared-mime-info


### PR DESCRIPTION
(This is stacked on top of https://github.com/heroku/base-images/pull/275.)

Since:
- Python apps will (or should be) be using Python provided by the Python buildpack instead.
- Non-Python buildpacks/apps typically don't need Python at runtime (or if they really do, then adding the Python buildpack is still preferred).
- Having Python in the run image has caused confusion in support tickets where the Python buildpack wasn't present (such as it being accidentally replaced when adding second buildpack), since at runtime apps then fail with a less obvious `ModuleNotFound` error instead of `python: command not found`.
- None of our other officially supported languages (that have their own buildpacks) are also installed as system packages in the base image.
- Removing Python reduces the run image size by 34 MB, and in a CNB world image size is a much bigger concern, so we need to be more selective about what packages we include.
- Once Heroku-24 GAs we can't remove packages (since it will break backwards compatibility given stack rebasing), however, we can add packages - so we should err on the side of trying out removing packages now.

Python is still in the build image since various non-Python use-cases need it (for example Node.js packages that use [node-gyp](https://www.npmjs.com/package/node-gyp) require Python at install time), plus several other system packages in the build image depend on `python3` anyway (so it's going to be installed regardless).

I've intentionally removed the `python-is-python3` package entirely (rather than still including it in the build image), since the vast majority of tooling will (or should be) checking for the presence of `python3` directly (given that's the default name on Ubuntu unless the backward compat package is installed; [node-gyp does for example](https://github.com/nodejs/node-gyp/blob/c4729129daa9bb5204246b857826fb391ac961e1/lib/find-python.js#L125-L134)). And for most end-user/app use-cases we would prefer they use the Python buildpack (rather than system Python), so a `python: command not found` will nudge them in that direction. We can always add `python-is-python3` back later if this turns out to be a bigger issue than expected.

Before (once the other PRs are merged):

```
-----> Size breakdown...
       heroku/heroku:24         424MB
       heroku/heroku:24-build   1.11GB
```

After:

```
-----> Size breakdown...
       heroku/heroku:24         390MB  (34 MB reduction)
       heroku/heroku:24-build   1.11GB (unchanged)
```

Note: The classic PHP buildpack does use Python in its `heroku-php-apache2` and `heroku-php-nginx` scripts, however, it's only used [when `realpath` doesn't exist](https://github.com/heroku/heroku-buildpack-php/blob/e74f1873cd924772738a97eb92f17dfdac05c4aa/bin/heroku-php-nginx#L12-L19) (eg macOS), so is unused on Heroku. The buildpack will need to [adjust](https://github.com/search?q=repo%3Aheroku%2Fheroku-buildpack-php%20python&type=code) for the `python-is-python3` removal, but arguably should have done that previously (given during the Python 2 -> 3 transition the major version of `python` changed). (If it needs to support environments where only the command `python` exists, and not `python3`, then it can use something like: `PYTHON=$(which python3 || which python)`)

There is also [Direwolf test or two](https://github.com/search?q=repo%3Aheroku%2Fdirewolf-tests+%22python3+-m%22&type=code) that will need updating, but (a) migrating those will be fairly easy (add the Python buildpack or switch to another alternative), (b) we shouldn't be bloating the run image for internal testing use-cases.

Towards #266.
GUS-W-15159536.