### PR TITLE
Fix publish-manifest script

### DIFF
--- a/tools/bin/publish-manifests
+++ b/tools/bin/publish-manifests
@@ -2,19 +2,17 @@
 
 set -euo pipefail
 
-if ls /tmp/*64-*.manifest >& /dev/null; then
-    jq --null-input \
-        '[inputs]
-        | map({
-            name: .name,
-            image_id: .id
-        }) | {stacks: .}' \
-        /tmp/*64-*.manifest |
-        curl \
-            --fail --user-agent 'Base Image Tools' \
-            --header "Authorization: Bearer $MANIFEST_APP_TOKEN" \
-            --header "Content-Type: application/json" \
-            --request PATCH \
-            --data @- \
-            "$MANIFEST_APP_URL/manifest/staging"
-fi
+jq --null-input --exit-status \
+    '[inputs]
+    | map({
+        name: .name,
+        image_id: .id
+    }) | {stacks: .}' \
+    /tmp/*.manifest \
+  | curl \
+      --fail --user-agent 'Base Image Tools' \
+      --header "Authorization: Bearer $MANIFEST_APP_TOKEN" \
+      --header "Content-Type: application/json" \
+      --request PATCH \
+      --data @- \
+      "$MANIFEST_APP_URL/manifest/staging"


### PR DESCRIPTION
At the very end of the image publishing process, Cheverny is notified that the images have been uploaded and the staging manifest should be updated, via the `publish-manifests` script.

For the v123 release, this script silently didn't publish the manifests:
https://github.com/heroku/base-images/actions/runs/8366257519/job/22906072260#step:7:123

(Compare to the previous release: https://github.com/heroku/base-images/actions/runs/8229492350/job/22500811676#step:7:101)

It turns out this is due to:
- The script relying on the glob `/tmp/*64-*.manifest` to determine which stacks were built.
- That glob no longer matching after #264 (where the `"64"` part of the filename was removed).

To make things worse, the script not only doesn't fail if no manifests are found, but it also piped any errors to `/dev/null`: `ls /tmp/*64-*.manifest >& /dev/null`

As such, I've:
- updated the glob to match the new manifest filename format
- removed the conditional (since there is no scenario in which the manifests being missing is expected)
- added `--exit-status` to the `jq` usage, to make it exit non-zero in more cases (jq would have exited non-zero for this no-files-matched case anyway, so this is just for completeness)

See:
https://jqlang.github.io/jq/manual/#invoking-jq

GUS-W-15304768.