### PR TITLE
Heroku-24: Migrate away from transitional packages

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -1,7 +1,6 @@
 # List of packages present in the final image. Regenerate using bin/build.sh
 adduser
 apt
-apt-transport-https
 apt-utils
 autoconf
 automake
@@ -35,7 +34,6 @@ debconf
 debianutils
 diffutils
 dirmngr
-dnsutils
 dpkg
 dpkg-dev
 e2fsprogs
@@ -204,7 +202,7 @@ libgdk-pixbuf2.0-0
 libgdk-pixbuf2.0-bin
 libgdk-pixbuf2.0-common
 libgeoip-dev
-libgeoip1
+libgeoip1t64
 libgfortran5
 libgirepository-2.0-0
 libglib2.0-0
@@ -562,7 +560,6 @@ shared-mime-info
 socat
 sysvinit-utils
 tar
-telnet
 tzdata
 ubuntu-keyring
 ucf

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -1,7 +1,6 @@
 # List of packages present in the final image. Regenerate using bin/build.sh
 adduser
 apt
-apt-transport-https
 apt-utils
 autoconf
 automake
@@ -35,7 +34,6 @@ debconf
 debianutils
 diffutils
 dirmngr
-dnsutils
 dpkg
 dpkg-dev
 e2fsprogs
@@ -204,7 +202,7 @@ libgdk-pixbuf2.0-0
 libgdk-pixbuf2.0-bin
 libgdk-pixbuf2.0-common
 libgeoip-dev
-libgeoip1
+libgeoip1t64
 libgfortran5
 libgirepository-2.0-0
 libglib2.0-0
@@ -561,7 +559,6 @@ shared-mime-info
 socat
 sysvinit-utils
 tar
-telnet
 tzdata
 ubuntu-keyring
 ucf

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -1,7 +1,6 @@
 # List of packages present in the final image. Regenerate using bin/build.sh
 adduser
 apt
-apt-transport-https
 apt-utils
 base-files
 base-passwd
@@ -20,7 +19,6 @@ debconf
 debianutils
 diffutils
 dirmngr
-dnsutils
 dpkg
 e2fsprogs
 ed
@@ -315,7 +313,6 @@ shared-mime-info
 socat
 sysvinit-utils
 tar
-telnet
 tzdata
 ubuntu-keyring
 ucf

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -1,7 +1,6 @@
 # List of packages present in the final image. Regenerate using bin/build.sh
 adduser
 apt
-apt-transport-https
 apt-utils
 base-files
 base-passwd
@@ -20,7 +19,6 @@ debconf
 debianutils
 diffutils
 dirmngr
-dnsutils
 dpkg
 e2fsprogs
 ed
@@ -315,7 +313,6 @@ shared-mime-info
 socat
 sysvinit-utils
 tar
-telnet
 tzdata
 ubuntu-keyring
 ucf

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -58,13 +58,12 @@ apt-get update --error-on=any
 apt-get upgrade -y --no-install-recommends
 
 packages=(
-  apt-transport-https
   apt-utils
-  bind9-host
+  # For dig, host and nslookup.
+  bind9-dnsutils
   bzip2
   coreutils
   curl
-  dnsutils
   ed
   file
   fontconfig
@@ -73,6 +72,7 @@ packages=(
   gir1.2-harfbuzz-0.0
   gnupg
   imagemagick
+  inetutils-telnet
   iproute2
   iputils-tracepath
   less
@@ -163,7 +163,6 @@ packages=(
   shared-mime-info
   socat
   tar
-  telnet
   tzdata
   unzip
   wget


### PR DESCRIPTION
Several of the packages being installed were actually transitional packages, that is, the package itself is either a complete no-op (since the functionality of the package is no needed), or else the package only exists to depend on another package of a new name (to support people who are still installing the package by its old name).

For the former, we can drop the dependency entirely, and for the latter we should use the new package name directly.

Specifically:
- `apt-transport-https`: APT supports HTTPS natively (and has since Ubuntu 18.04), so this package doesn't do anything: 
    - https://packages.ubuntu.com/focal/apt-transport-https
    - https://packages.ubuntu.com/focal/all/apt-transport-https/filelist
- `dnsutils` renamed to `bind9-dnsutils`: 
    - https://packages.ubuntu.com/noble/dnsutils
    - https://packages.ubuntu.com/noble/all/dnsutils/filelist
- `bind9-host`: It is part of `bind9-dnsutils`, so we don't need to depoend on it directly:
    - https://packages.ubuntu.com/noble/bind9-dnsutils
- `telnet` renamed to `inetutils-telnet`:
    - https://packages.ubuntu.com/noble/telnet
    - https://packages.ubuntu.com/noble/all/telnet/filelist

These changes are a no-op in terms of end functionality of the images.

Note: The `libgeoip1` -> `libgeoip1t64` rename is to make CI pass since the package has been renamed upstream as part of the 64-bit time_t transition:
https://lists.debian.org/debian-devel-announce/2024/02/msg00005.html