### PR TITLE
Heroku-24: Update packages list for upstream changes

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -332,7 +332,6 @@ libnetpbm11
 libnettle8
 libnghttp2-14
 libnpth0
-libnsl-dev
 libnsl2
 libnspr4
 libnss3
@@ -440,7 +439,6 @@ libtiff6
 libtiffxx6
 libtinfo6
 libtirpc-common
-libtirpc-dev
 libtirpc3
 libtool
 libtsan2

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -332,7 +332,6 @@ libnetpbm11
 libnettle8
 libnghttp2-14
 libnpth0
-libnsl-dev
 libnsl2
 libnspr4
 libnss3
@@ -439,7 +438,6 @@ libtiff6
 libtiffxx6
 libtinfo6
 libtirpc-common
-libtirpc-dev
 libtirpc3
 libtool
 libtsan2


### PR DESCRIPTION
Upstream changes have meant the list of installed packages has changed - `libc6-dev` used to depend upon `libnsl-dev`, but no longer does:
https://git.launchpad.net/ubuntu/+source/glibc/commit/?id=c2757e3aa9550d2b1e1d1ade188f97b66a4eb648

We don't need this package, so won't install it explicitly:
https://packages.ubuntu.com/noble/libnsl-dev

This updates the list of packages installed in the image to match reality, and to make CI pass.

GUS-W-15159536.