### PR TITLE
Fix Heroku-24 builds again

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -237,7 +237,7 @@ libhashkit-dev
 libhashkit2t64
 libhdf5-103-1t64
 libheif-dev
-libheif-plugin-dav1d
+libheif-plugin-aomdec
 libheif-plugin-libde265
 libheif1
 libhogweed6t64

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -230,7 +230,7 @@ libhashkit-dev
 libhashkit2t64
 libhdf5-103-1t64
 libheif-dev
-libheif-plugin-dav1d
+libheif-plugin-aomdec
 libheif-plugin-libde265
 libheif1
 libhogweed6t64

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -132,7 +132,7 @@ libharfbuzz-icu0
 libharfbuzz0b
 libhashkit2t64
 libhdf5-103-1t64
-libheif-plugin-dav1d
+libheif-plugin-aomdec
 libheif-plugin-libde265
 libheif1
 libhogweed6t64

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -132,7 +132,7 @@ libharfbuzz-icu0
 libharfbuzz0b
 libhashkit2t64
 libhdf5-103-1t64
-libheif-plugin-dav1d
+libheif-plugin-aomdec
 libheif-plugin-libde265
 libheif1
 libhogweed6t64


### PR DESCRIPTION
Since the transitive package list has changed upstream again:
https://github.com/heroku/base-images/actions/runs/8711767534/job/24023021246

The new package lists were regenerated by running `./bin/build.sh 24`.