### PR TITLE
Heroku-24: Switch editor from `ed` to `nano`

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -37,7 +37,6 @@ dirmngr
 dpkg
 dpkg-dev
 e2fsprogs
-ed
 file
 findutils
 fontconfig
@@ -517,6 +516,7 @@ media-types
 mlock
 mount
 mysql-common
+nano
 ncurses-base
 ncurses-bin
 netbase

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -37,7 +37,6 @@ dirmngr
 dpkg
 dpkg-dev
 e2fsprogs
-ed
 file
 findutils
 fontconfig
@@ -509,6 +508,7 @@ media-types
 mlock
 mount
 mysql-common
+nano
 ncurses-base
 ncurses-bin
 netbase

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -21,7 +21,6 @@ diffutils
 dirmngr
 dpkg
 e2fsprogs
-ed
 file
 findutils
 fontconfig
@@ -284,6 +283,7 @@ mawk
 mlock
 mount
 mysql-common
+nano
 ncurses-base
 ncurses-bin
 netbase

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -21,7 +21,6 @@ diffutils
 dirmngr
 dpkg
 e2fsprogs
-ed
 file
 findutils
 fontconfig
@@ -284,6 +283,7 @@ mawk
 mlock
 mount
 mysql-common
+nano
 ncurses-base
 ncurses-bin
 netbase

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -64,7 +64,6 @@ packages=(
   bzip2
   coreutils
   curl
-  ed
   file
   fontconfig
   geoip-database
@@ -152,6 +151,8 @@ packages=(
   libzstd1
   locales
   lsb-release
+  # Nano is more usable than ed but still much smaller than vim.
+  nano
   netcat-openbsd
   openssh-client
   openssh-server


### PR DESCRIPTION
Whilst using an editor inside dynos is generally discouraged (since changes by design won't persist), it's sometimes unavoidable when debugging.

Previously the only options were to either:
1. Use `ed`, which is pretty user-unfriendly (it somehow manages to be harder than Vim to quit)
2. Dynamically download a hacked together install of Vim onto the dyno

As such in a recent discussion we proposed adding `nano` instead, since its more usable than `ed` but smaller than `vim` (`vim` is 70 MB, `vim-tiny` 4 MB, `nano` 0.9 MB, and `ed` 0.1 MB).

See:
https://salesforce-internal.slack.com/archives/C02GZCPPV38/p1709225255361399?thread_ts=1709054633.272659&cid=C02GZCPPV38

GUS-W-15159536.