### PR TITLE
Heroku-24: Switch from `libgdk-pixbuf2.0-0` to `libgdk-pixbuf-2.0-0`

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -200,8 +200,6 @@ libgdbm-dev
 libgdbm6t64
 libgdk-pixbuf-2.0-0
 libgdk-pixbuf-2.0-dev
-libgdk-pixbuf-xlib-2.0-0
-libgdk-pixbuf2.0-0
 libgdk-pixbuf2.0-bin
 libgdk-pixbuf2.0-common
 libgeoip-dev

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -196,8 +196,6 @@ libgdbm-dev
 libgdbm6t64
 libgdk-pixbuf-2.0-0
 libgdk-pixbuf-2.0-dev
-libgdk-pixbuf-xlib-2.0-0
-libgdk-pixbuf2.0-0
 libgdk-pixbuf2.0-bin
 libgdk-pixbuf2.0-common
 libgeoip-dev

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -115,8 +115,6 @@ libgd3
 libgdbm-compat4t64
 libgdbm6t64
 libgdk-pixbuf-2.0-0
-libgdk-pixbuf-xlib-2.0-0
-libgdk-pixbuf2.0-0
 libgdk-pixbuf2.0-common
 libglib2.0-0t64
 libgmp10

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -115,8 +115,6 @@ libgd3
 libgdbm-compat4t64
 libgdbm6t64
 libgdk-pixbuf-2.0-0
-libgdk-pixbuf-xlib-2.0-0
-libgdk-pixbuf2.0-0
 libgdk-pixbuf2.0-common
 libglib2.0-0t64
 libgmp10

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -64,7 +64,7 @@ packages=(
   libevent-openssl-2.1-7
   libevent-pthreads-2.1-7
   libgd3
-  libgdk-pixbuf2.0-0
+  libgdk-pixbuf-2.0-0
   libgnutls-openssl27
   libgnutls30
   libharfbuzz-icu0


### PR DESCRIPTION
Since the former is a transitional package, that already depends upon the latter:
https://packages.ubuntu.com/noble/libgdk-pixbuf2.0-0
https://packages.ubuntu.com/noble/libgdk-pixbuf-2.0-0

The new package doesn't depend upon `libgdk-pixbuf-xlib-2.0-0`, however, that package is deprecated, and nothing appears to use it.

This also means we're using fewer packages from `universe` (which has lesser support guarantees), since the old packages are in `universe` unlike the new ones that are in `main`.

GUS-W-15159536.