### PR TITLE
Heroku-24: Update comment about `locale-gen`

### DIFF
--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -119,8 +119,9 @@ packages=(
 
 apt-get install -y --no-install-recommends "${packages[@]}"
 
-# Generate locale data for "en_US", which is not available by default. Ubuntu
-# ships only with "C" and "POSIX" locales.
+# Generate locale data for "en_US.UTF-8" too, since the upstream Ubuntu image
+# only ships with the "C", "C.utf8" and "POSIX" locales:
+# https://github.com/docker-library/docs/blob/master/ubuntu/README.md#locales
 locale-gen en_US.UTF-8
 
 # Temporarily install ca-certificates-java to generate the certificates store used


### PR DESCRIPTION
Adds some more detail, and also the missing `C.utf8` reference, since that's also in the default locales list for the base `ubuntu:24.04` image:

```
$ locale -a
C
C.utf8
POSIX
```

See also:
https://github.com/docker-library/docs/blob/master/ubuntu/README.md#locales
https://help.ubuntu.com/community/Locale
https://manpages.ubuntu.com/manpages/noble/en/man8/locale-gen.8.html