### PR TITLE
Heroku-24: Migrate away from transitional packages (build image)

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -245,7 +245,6 @@ libice6
 libicu-dev
 libicu74
 libidn-dev
-libidn11-dev
 libidn12
 libidn2-0
 libidn2-dev
@@ -282,7 +281,6 @@ liblcms2-2
 liblcms2-dev
 libldap-dev
 libldap2
-libldap2-dev
 liblerc-dev
 liblerc4
 liblmdb0

--- a/heroku-24-build/setup.sh
+++ b/heroku-24-build/setup.sh
@@ -38,12 +38,12 @@ packages=(
   libgnutls28-dev
   libheif-dev
   libicu-dev
-  libidn11-dev
+  libidn-dev
   libjpeg-dev
   libkeyutils-dev
   libkmod-dev
   libkrb5-dev
-  libldap2-dev
+  libldap-dev
   liblz4-dev
   liblzf-dev
   libmagic-dev
@@ -51,8 +51,7 @@ packages=(
   libmcrypt-dev
   libmemcached-dev
   libmysqlclient-dev
-  libncurses5-dev
-  libncursesw5-dev
+  libncurses-dev
   libnetpbm10-dev
   libonig-dev
   libpam0g-dev


### PR DESCRIPTION
This is the build image equivalent of #279.

Several packages in the package install list for the build image are actually transitional packages - which provide backwards compatibility for packages that have since been renamed/replaced. Instead of depending on the old transitional package name, we should switch to the new names.

Specifically:
* [libidn11-dev](https://packages.ubuntu.com/noble/libidn11-dev) -> [libidn-dev](https://packages.ubuntu.com/noble/libidn-dev)
* [libldap2-dev](https://packages.ubuntu.com/noble/libldap2-dev) -> [libldap-dev](https://packages.ubuntu.com/noble/libldap-dev)
* [libncurses5-dev](https://packages.ubuntu.com/noble/libncurses5-dev) and [libncursesw5-dev](https://packages.ubuntu.com/noble/libncursesw5-dev) -> [libncurses-dev](https://packages.ubuntu.com/noble/libncurses-dev)

This is a no-op in terms of actual libs/headers installed in the build image (the packages seen being removed in the packages list are empty packages that solely depended on the new package name, which was already being installed).

GUS-W-15616760.