### PR TITLE
Heroku-24: Omit transitive deps from package install list (build image)

### DIFF
--- a/heroku-24-build/setup.sh
+++ b/heroku-24-build/setup.sh
@@ -17,7 +17,6 @@ packages=(
   libacl1-dev
   libapt-pkg-dev
   libargon2-dev
-  libattr1-dev
   libaudit-dev
   libbsd-dev
   libbz2-dev
@@ -34,7 +33,6 @@ packages=(
   libgd-dev
   libgdbm-dev
   libgeoip-dev
-  libglib2.0-dev
   libgnutls28-dev
   libheif-dev
   libicu-dev
@@ -51,17 +49,14 @@ packages=(
   libmcrypt-dev
   libmemcached-dev
   libmysqlclient-dev
-  libncurses-dev
   libnetpbm10-dev
   libonig-dev
-  libpam0g-dev
   libpopt-dev
   libpq-dev
   librabbitmq-dev
   libreadline-dev
   librtmp-dev
   libseccomp-dev
-  libselinux1-dev
   libsemanage-dev
   libsodium-dev
   libssl-dev


### PR DESCRIPTION
This is the build image equivalent of #285.

Several of the packages in the list of packages to install in the build image are actually already transitive dependencies of other packages.

For packages that we absolutely need regardless, it makes sense to still include these transitive deps explicitly in the list. However, some of the transitive deps are actually packages we wouldn't choose to install if they weren't already a dependency of something else. This change omits such entries.

This change is a no-op in terms of the final images (note how there is no change to the generated `installed-packages-*.txt` lists), but makes it easier to follow/audit the remaining packages in the list.

GUS-W-15159536.