### PR TITLE
Heroku-24: Re-sync ARM64 package lists

### DIFF
--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -238,7 +238,6 @@ libice6
 libicu-dev
 libicu74
 libidn-dev
-libidn11-dev
 libidn12
 libidn2-0
 libidn2-dev
@@ -275,7 +274,6 @@ liblcms2-2
 liblcms2-dev
 libldap-dev
 libldap2
-libldap2-dev
 liblerc-dev
 liblerc4
 liblmdb0


### PR DESCRIPTION
This regenerates the ARM64 packages list to match reality (and the AMD64 lists) after #292.

CI unfortunately didn't catch this, since it currently only validates the AMD64 list due to (a) the limitations around Docker on Linux not supporting the containerd snapshotter and so multi-arch images, and (b) the fact CI currently builds both architectures on the same machine.

Also, the reason my running the build generation script locally didn't update the ARM64 manifests, is that when I'm image size benchmarking I sadly have to disable the containerd snapshotter since it has broken image size calculations. With the current build scripts for this repo, that results in only AMD64 being generated locally.

GUS-W-15616760.