### PR TITLE
Heroku-24: Remove `apt-utils` and `rename`

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -1,7 +1,6 @@
 # List of packages present in the final image. Regenerate using bin/build.sh
 adduser
 apt
-apt-utils
 autoconf
 automake
 autotools-dev
@@ -546,7 +545,6 @@ python3-setuptools
 python3.12
 python3.12-minimal
 readline-common
-rename
 rpcsvc-proto
 rsync
 sed

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -1,7 +1,6 @@
 # List of packages present in the final image. Regenerate using bin/build.sh
 adduser
 apt
-apt-utils
 autoconf
 automake
 autotools-dev
@@ -533,7 +532,6 @@ python3-packaging
 python3.12
 python3.12-minimal
 readline-common
-rename
 rpcsvc-proto
 rsync
 sed

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -1,7 +1,6 @@
 # List of packages present in the final image. Regenerate using bin/build.sh
 adduser
 apt
-apt-utils
 base-files
 base-passwd
 bash
@@ -301,7 +300,6 @@ postgresql-client-16
 postgresql-client-common
 procps
 readline-common
-rename
 rsync
 sed
 sensible-utils

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -1,7 +1,6 @@
 # List of packages present in the final image. Regenerate using bin/build.sh
 adduser
 apt
-apt-utils
 base-files
 base-passwd
 bash
@@ -301,7 +300,6 @@ postgresql-client-16
 postgresql-client-common
 procps
 readline-common
-rename
 rsync
 sed
 sensible-utils

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -38,7 +38,6 @@ apt-get update --error-on=any
 apt-get upgrade -y --no-install-recommends
 
 packages=(
-  apt-utils
   # For dig, host and nslookup.
   bind9-dnsutils
   bzip2
@@ -105,7 +104,6 @@ packages=(
   patch
   poppler-utils
   postgresql-client-16
-  rename
   rsync
   socat
   tar


### PR DESCRIPTION
Since:
- The [apt-utils](https://packages.ubuntu.com/noble/apt-utils) package is only needed for an optional UX improvement for interactive APT workflows, so isn't needed in a container context. See: https://unix.stackexchange.com/a/629114
- The [rename](https://packages.ubuntu.com/noble/rename) package [provides](https://packages.ubuntu.com/noble/all/rename/filelist) the commands [file-rename](https://manpages.ubuntu.com/manpages/noble/en/man1/file-rename.1p.html) and [prename](https://manpages.ubuntu.com/manpages/noble/en/man1/prename.1p.html), which are pretty obscure and not something that many/any apps will be using at run-time (and have zero usages seen in GitHub code search across all of our repos; [search-1](https://github.com/search?q=org%3Aheroku+%2F%5Cbfile-rename%5Cb%2F&type=code), [search-2](https://github.com/search?q=org%3Aheroku+%2F%5Cbprename%5Cb%2F&type=code))

GUS-W-15159536.