### PR TITLE
Heroku-24: Remove libmcrypt4 / libmcrypt-dev

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -300,8 +300,6 @@ libmagickwand-6.q16-dev
 libmagickwand-dev
 libmatio11
 libmaxminddb0
-libmcrypt-dev
-libmcrypt4
 libmd-dev
 libmd0
 libmemcached-dev

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -293,8 +293,6 @@ libmagickwand-6.q16-dev
 libmagickwand-dev
 libmatio11
 libmaxminddb0
-libmcrypt-dev
-libmcrypt4
 libmd-dev
 libmd0
 libmemcached-dev

--- a/heroku-24-build/setup.sh
+++ b/heroku-24-build/setup.sh
@@ -39,7 +39,6 @@ packages=(
   liblzf-dev
   libmagic-dev
   libmagickwand-dev
-  libmcrypt-dev
   libmemcached-dev
   libmysqlclient-dev
   libnetpbm10-dev

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -163,7 +163,6 @@ libmagickcore-6.q16-7t64
 libmagickwand-6.q16-7t64
 libmatio11
 libmaxminddb0
-libmcrypt4
 libmd0
 libmemcached11t64
 libmnl0

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -163,7 +163,6 @@ libmagickcore-6.q16-7t64
 libmagickwand-6.q16-7t64
 libmatio11
 libmaxminddb0
-libmcrypt4
 libmd0
 libmemcached11t64
 libmnl0

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -68,7 +68,6 @@ packages=(
   libharfbuzz-icu0 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   liblzf1 # Used by the PHP Redis extension.
   libmagickcore-6.q16-7-extra # Used by the PHP Imagick extension (using the `-extra` package for SVG support).
-  libmcrypt4
   libmemcached11 # Used by the PHP Memcached extension.
   libmp3lame0 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   libmysqlclient21


### PR DESCRIPTION
Since they were added in #149 only for the PHP buildpack's benefit, however, are no longer used by PHP as of PHP 7.2+:
https://github.com/heroku/heroku-buildpack-php/commit/0ce0fc5567770a3a7a8a81fd6b27fb055a2034d2#diff-a8ff7bd14bd2bddfbf6e7c733a14badb0e7a4d566abbfd4d20948dfc998b6a87L59

The few bindings I could find for other langs are all (a) not popular, (b) in a state of disrepair, eg:
https://github.com/tugrul/node-mcrypt (70 stars, last commit 5 years ago)
https://github.com/kingpong/ruby-mcrypt (22 stars, last commit 7 years ago)
(Which is not surprising given much better alternatives exist, such as Sodium, which is already in the base image.)

GUS-W-15159536.