### PR TITLE
Heroku-24: Remove `geoip-database` / `libgeoip-dev`

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -52,8 +52,6 @@ gcc-13-base
 gcc-13-x86-64-linux-gnu
 gcc-14-base
 gcc-x86-64-linux-gnu
-geoip-bin
-geoip-database
 gettext
 gettext-base
 gir1.2-freedesktop
@@ -195,8 +193,6 @@ libgdk-pixbuf-2.0-0
 libgdk-pixbuf-2.0-dev
 libgdk-pixbuf2.0-bin
 libgdk-pixbuf2.0-common
-libgeoip-dev
-libgeoip1t64
 libgirepository-1.0-1
 libgirepository-1.0-dev
 libgirepository-2.0-0

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -52,8 +52,6 @@ gcc-13-aarch64-linux-gnu
 gcc-13-base
 gcc-14-base
 gcc-aarch64-linux-gnu
-geoip-bin
-geoip-database
 gettext
 gettext-base
 gir1.2-freedesktop
@@ -191,8 +189,6 @@ libgdk-pixbuf-2.0-0
 libgdk-pixbuf-2.0-dev
 libgdk-pixbuf2.0-bin
 libgdk-pixbuf2.0-common
-libgeoip-dev
-libgeoip1t64
 libgirepository-2.0-0
 libglib2.0-0t64
 libglib2.0-bin

--- a/heroku-24-build/setup.sh
+++ b/heroku-24-build/setup.sh
@@ -27,7 +27,6 @@ packages=(
   libgcrypt20-dev
   libgd-dev
   libgdbm-dev
-  libgeoip-dev
   libgnutls28-dev
   libheif-dev
   libicu-dev

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -27,7 +27,6 @@ fontconfig-config
 fonts-dejavu-core
 fonts-dejavu-mono
 gcc-14-base
-geoip-database
 gettext-base
 gir1.2-freedesktop
 gir1.2-glib-2.0

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -27,7 +27,6 @@ fontconfig-config
 fonts-dejavu-core
 fonts-dejavu-mono
 gcc-14-base
-geoip-database
 gettext-base
 gir1.2-freedesktop
 gir1.2-glib-2.0

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -42,7 +42,6 @@ packages=(
   bzip2
   curl
   file
-  geoip-database
   gettext-base # For `envsubst`.
   gir1.2-harfbuzz-0.0 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   gnupg


### PR DESCRIPTION
Since:
* It's a niche package, that appears to only be installed since it was a transitive dependency of `dnsutils` in Cedar-14, which was then copied to Heroku-16 as an explicit dependency along with a number of others, when that stack was added.
* The `libgeoip1` library (that is needed along with `geoip-database` to actually use it) has been missing from the run image since Heroku-20, and no one has noticed its absence.
* It reduces the run/build image sizes by  ~10 MB.

See:
https://packages.ubuntu.com/noble/geoip-database
https://packages.ubuntu.com/noble/libgeoip-dev

Towards #266.
GUS-W-15159536.