### PR TITLE
Heroku-24: Remove `libnetpbm10-dev`

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -311,7 +311,6 @@ libmysqlclient-dev
 libmysqlclient21
 libncurses6
 libncursesw6
-libnetpbm11t64
 libnettle8t64
 libnghttp2-14
 libnpth0t64

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -304,7 +304,6 @@ libmysqlclient-dev
 libmysqlclient21
 libncurses6
 libncursesw6
-libnetpbm11t64
 libnettle8t64
 libnghttp2-14
 libnpth0t64

--- a/heroku-24-build/setup.sh
+++ b/heroku-24-build/setup.sh
@@ -40,7 +40,6 @@ packages=(
   libmagickwand-dev
   libmemcached-dev
   libmysqlclient-dev
-  libnetpbm10-dev
   libonig-dev
   libpq-dev
   librabbitmq-dev


### PR DESCRIPTION
Since:
- The `libnetpbm10-dev` package is actually an empty virtual package,
- The runtime library it pulls in (`libnetpbm11`) isn't in any of our run images (all the way back to Heroku-18), meaning it's not actually usable at runtime anyway, and yet no one has reported its absence in the last 6 years.

See:
https://packages.ubuntu.com/noble/libnetpbm10-dev
https://netpbm.sourceforge.net/doc/libnetpbm.html

Towards #266.
GUS-W-15159536.