### PR TITLE
Heroku-24: Remove `libgcrypt20-dev`

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -183,7 +183,6 @@ libfribidi0
 libgcc-13-dev
 libgcc-s1
 libgcrypt20
-libgcrypt20-dev
 libgd-dev
 libgd3
 libgdbm-compat4t64
@@ -210,7 +209,6 @@ libgnutls-openssl27t64
 libgnutls28-dev
 libgnutls30t64
 libgomp1
-libgpg-error-dev
 libgpg-error0
 libgprofng0
 libgraphite2-3

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -179,7 +179,6 @@ libfribidi0
 libgcc-13-dev
 libgcc-s1
 libgcrypt20
-libgcrypt20-dev
 libgd-dev
 libgd3
 libgdbm-compat4t64
@@ -203,7 +202,6 @@ libgnutls-openssl27t64
 libgnutls28-dev
 libgnutls30t64
 libgomp1
-libgpg-error-dev
 libgpg-error0
 libgprofng0
 libgraphite2-3

--- a/heroku-24-build/setup.sh
+++ b/heroku-24-build/setup.sh
@@ -24,7 +24,6 @@ packages=(
   libevent-dev
   libexif-dev
   libffi-dev
-  libgcrypt20-dev
   libgd-dev
   libgdbm-dev
   libgnutls28-dev


### PR DESCRIPTION
Since:
- All of the language bindings I could find for it were unpopular and not actively maintained. For example:
  - Ruby: https://github.com/chrisliaw/gcrypt (last commit 3 years ago, 0 stars, not published to rubygems.org)
  - Python: https://framagit.org/okhin/pygcrypt/ (last commit 6 years ago, 0 stars, close to zero [PyPI downloads](https://pypistats.org/packages/pygcrypt) excl mirrors syncing)
- It's the dev package for the library extracted from GnuPG, and it's much more common to interact with the `gpg` CLI directly. eg: https://github.com/vsajip/python-gnupg (8 million downloads/month) which uses the CLI instead.

See:
https://packages.ubuntu.com/noble/libgcrypt20-dev
https://gnupg.org/software/libgcrypt/

Towards #266.
GUS-W-15159536.