### PR TITLE
Heroku-24: Remove `libdb-dev`

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -143,8 +143,6 @@ libcurl4t64
 libdatrie1
 libdav1d-dev
 libdav1d7
-libdb-dev
-libdb5.3-dev
 libdb5.3t64
 libde265-0
 libde265-dev

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -139,8 +139,6 @@ libcurl4t64
 libdatrie1
 libdav1d-dev
 libdav1d7
-libdb-dev
-libdb5.3-dev
 libdb5.3t64
 libde265-0
 libde265-dev

--- a/heroku-24-build/setup.sh
+++ b/heroku-24-build/setup.sh
@@ -19,7 +19,6 @@ packages=(
   libc-client2007e-dev
   libcairo2-dev
   libcurl4-openssl-dev
-  libdb-dev
   libev-dev
   libevent-dev
   libexif-dev


### PR DESCRIPTION
Since:
- This is the dev package for `libdb5.3`, a lib for Berkeley DB, which as DBs go is fairly obscure.
- The main reason this is in the base image, is since the Python stdlib contains a module for Berkeley DB (`dbm.ndbm`), however, we don't need the headers in the build image for that (since they can be installed in the image where the Python runtimes are built instead).
- There are very few language bindings for `libdb`, and those I could find were unpopular and not actively maintained. eg: https://github.com/ruby-bdb/bdb (38 stars, last commit and rubygems.org release in 2011)

See:
https://packages.ubuntu.com/noble/libdb-dev

Towards #266.
GUS-W-15159536.