### PR TITLE
Heroku-24: Remove `libc-client2007e-dev`

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -117,7 +117,6 @@ libbz2-1.0
 libbz2-dev
 libc-bin
 libc-client2007e
-libc-client2007e-dev
 libc-dev-bin
 libc6
 libc6-dev
@@ -330,7 +329,6 @@ libpam-modules
 libpam-modules-bin
 libpam-runtime
 libpam0g
-libpam0g-dev
 libpango-1.0-0
 libpangocairo-1.0-0
 libpangoft2-1.0-0

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -113,7 +113,6 @@ libbz2-1.0
 libbz2-dev
 libc-bin
 libc-client2007e
-libc-client2007e-dev
 libc-dev-bin
 libc6
 libc6-dev
@@ -323,7 +322,6 @@ libpam-modules
 libpam-modules-bin
 libpam-runtime
 libpam0g
-libpam0g-dev
 libpango-1.0-0
 libpangocairo-1.0-0
 libpangoft2-1.0-0

--- a/heroku-24-build/setup.sh
+++ b/heroku-24-build/setup.sh
@@ -16,7 +16,6 @@ packages=(
   libargon2-dev
   libbsd-dev
   libbz2-dev
-  libc-client2007e-dev
   libcairo2-dev
   libcurl4-openssl-dev
   libev-dev


### PR DESCRIPTION
Since:
- It was added in #146 along with the `libc-client2007e` runtime library for use by PHP, however, for PHP's use-case (binary compilation) the headers don't need to be in the build image itself, but can instead be installed during the PHP binary build process.
- There are no other popular `libc-client2007e` bindings for languages other than PHP that use these headers. (Compared to the other LDAP library already in the build image, `libldap-dev`, for which there are several popular bindings - including [python-ldap](https://pypistats.org/packages/python-ldap) with 1.8 million downloads/month.)

See:
https://packages.ubuntu.com/noble/libc-client2007e-dev

Towards #266.
GUS-W-15159536.