### PR TITLE
Add Heroku-24 to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,28 @@
 This repository holds recipes for building the base images for [Heroku stacks](https://devcenter.heroku.com/articles/stack).
 The recipes are also rendered into Docker images that are available on Docker Hub:
 
-| Image                                     | Base                                  | Type               | Status      |
-|-------------------------------------------|---------------------------------------|--------------------|-------------|
-| [heroku/heroku:18][heroku-tags]           | [ubuntu:18.04][ubuntu-tags]           | Heroku Run Image   | End-of-life |
-| [heroku/heroku:18-build][heroku-tags]     | [heroku/heroku:18][heroku-tags]       | Heroku Build Image | End-of-life |
-| [heroku/heroku:18-cnb][heroku-tags]       | [heroku/heroku:18][heroku-tags]       | CNB Run Image      | End-of-life |
-| [heroku/heroku:18-cnb-build][heroku-tags] | [heroku/heroku:18-build][heroku-tags] | CNB Build Image    | End-of-life |
-| [heroku/heroku:20][heroku-tags]           | [ubuntu:20.04][ubuntu-tags]           | Heroku Run Image   | Available   |
-| [heroku/heroku:20-build][heroku-tags]     | [heroku/heroku:20][heroku-tags]       | Heroku Build Image | Available   |
-| [heroku/heroku:20-cnb][heroku-tags]       | [heroku/heroku:20][heroku-tags]       | CNB Run Image      | Available   |
-| [heroku/heroku:20-cnb-build][heroku-tags] | [heroku/heroku:20-build][heroku-tags] | CNB Build Image    | Available   |
-| [heroku/heroku:22][heroku-tags]           | [ubuntu:22.04][ubuntu-tags]           | Heroku Run Image   | Recommended |
-| [heroku/heroku:22-build][heroku-tags]     | [heroku/heroku:22][heroku-tags]       | Heroku Build Image | Recommended |
-| [heroku/heroku:22-cnb][heroku-tags]       | [heroku/heroku:22][heroku-tags]       | CNB Run Image      | Recommended |
-| [heroku/heroku:22-cnb-build][heroku-tags] | [heroku/heroku:22-build][heroku-tags] | CNB Build Image    | Recommended |
+| Image                                     | Type                   | OS           | Supported Architectures | Default `USER` | Status          |
+|-------------------------------------------|------------------------|--------------|-------------------------|----------------| ----------------|
+| [heroku/heroku:20][heroku-tags]           | Heroku Run Image       | Ubuntu 20.04 | AMD64                   | `root`         |  Available      |
+| [heroku/heroku:20-build][heroku-tags]     | Heroku Build Image     | Ubuntu 20.04 | AMD64                   | `root`         |  Available      |
+| [heroku/heroku:20-cnb][heroku-tags]       | CNB Run Image          | Ubuntu 20.04 | AMD64                   | `heroku`       |  Available      |
+| [heroku/heroku:20-cnb-build][heroku-tags] | CNB Build Image        | Ubuntu 20.04 | AMD64                   | `heroku`       |  Available      |
+| [heroku/heroku:22][heroku-tags]           | Heroku Run Image       | Ubuntu 22.04 | AMD64                   | `root`         |  Recommended    |
+| [heroku/heroku:22-build][heroku-tags]     | Heroku Build Image     | Ubuntu 22.04 | AMD64                   | `root`         |  Recommended    |
+| [heroku/heroku:22-cnb][heroku-tags]       | CNB Run Image          | Ubuntu 22.04 | AMD64                   | `heroku`       |  Available      |
+| [heroku/heroku:22-cnb-build][heroku-tags] | CNB Build Image        | Ubuntu 22.04 | AMD64                   | `heroku`       |  Available      |
+| [heroku/heroku:24][heroku-tags]           | Heroku/CNB Run Image   | Ubuntu 24.04 | AMD64 + ARM64           | `heroku`       |  In Development |
+| [heroku/heroku:24-build][heroku-tags]     | Heroku/CNB Build Image | Ubuntu 24.04 | AMD64 + ARM64           | `heroku`       |  In Development |
+
+The build image variants use the run images as their base, but include additional packages needed
+at build time such as development headers and compilation toolchains.
+
+The CNB image variants contain additional metadata and changes required to make them compatible with
+Heroku's Cloud Native Buildpacks [builder images](https://github.com/heroku/cnb-builder-images).
+
+For images where the default `USER` is `heroku`, you will need to switch back to the `root` user when
+modifying locations other then `/home/heroku` and `/tmp`. You can do this by adding `USER root` to
+your `Dockerfile` when building images, or by passing `--user root` to any `docker run` invocations.
 
 ### Learn more
 


### PR DESCRIPTION
Now that Ubuntu 24.04 is GA, and we've finished with the package cleanups/removals, we can add Heroku-24 to the README. It's listed as "In Development" for now (similar to the CNB builder image repo README) since Heroku-24 itself isn't yet GA and not all buildpacks support the new stack yet.

I've also:
- Removed mention of Heroku-18, since it EOLed over a year ago.
- Added new columns for "Supported Architectures" and "Default USER", given that these vary across images.
- Removed the "Base" column since (a) the table is otherwise too wide to fit when rendered on the repo homepage on GitHub, (b) that information was the least useful of everything else (and also IMO potentially confused as many people as it helped, given it might be confused with the very similar tag names in the "Image" column).
- Added explanations about the build and CNB image variants.
- Documented how to handle the non-root default users.

See also the corresponding images table in the builder images repo:
https://github.com/heroku/cnb-builder-images?tab=readme-ov-file#available-images

GUS-W-15756540.