### PR TITLE
Add `c-ares` to the run image for all stacks

### DIFF
--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -127,6 +127,7 @@ libbsd-dev
 libbsd0
 libbz2-1.0
 libbz2-dev
+libc-ares2
 libc-bin
 libc-client2007e
 libc-client2007e-dev

--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -93,6 +93,7 @@ libblkid1
 libbrotli1
 libbsd0
 libbz2-1.0
+libc-ares2
 libc-bin
 libc-client2007e
 libc-dev-bin

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -53,6 +53,7 @@ packages=(
   libaom0
   libargon2-1
   libass9
+  libc-ares2 # Used by PgBouncer in heroku-buildpack-pgbouncer.
   libc-client2007e
   libc6-dev
   libcairo2

--- a/heroku-22-build/installed-packages.txt
+++ b/heroku-22-build/installed-packages.txt
@@ -127,6 +127,7 @@ libbsd-dev
 libbsd0
 libbz2-1.0
 libbz2-dev
+libc-ares2
 libc-bin
 libc-client2007e
 libc-client2007e-dev

--- a/heroku-22/installed-packages.txt
+++ b/heroku-22/installed-packages.txt
@@ -93,6 +93,7 @@ libbpf0
 libbrotli1
 libbsd0
 libbz2-1.0
+libc-ares2
 libc-bin
 libc-client2007e
 libc-dev-bin

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -53,6 +53,7 @@ packages=(
   libaom3
   libargon2-1
   libass9
+  libc-ares2 # Used by PgBouncer in heroku-buildpack-pgbouncer.
   libc-client2007e
   libc6-dev
   libcairo2

--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -127,6 +127,7 @@ libcairo2-dev
 libcap-ng0
 libcap2
 libcap2-bin
+libcares2
 libcbor0.10
 libcc1-0
 libcfitsio10t64

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -123,6 +123,7 @@ libcairo2-dev
 libcap-ng0
 libcap2
 libcap2-bin
+libcares2
 libcbor0.10
 libcc1-0
 libcfitsio10t64

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -79,6 +79,7 @@ libcairo2
 libcap-ng0
 libcap2
 libcap2-bin
+libcares2
 libcbor0.10
 libcfitsio10t64
 libcgif0

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -79,6 +79,7 @@ libcairo2
 libcap-ng0
 libcap2
 libcap2-bin
+libcares2
 libcbor0.10
 libcfitsio10t64
 libcgif0

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -54,6 +54,7 @@ packages=(
   libargon2-1 # Used by the PHP runtime.
   libass9 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   libc-client2007e # Used by the PHP IMAP extension.
+  libcares2 # Used by PgBouncer in heroku-buildpack-pgbouncer.
   libdav1d7 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   libev4
   libevent-2.1-7 # Used by PgBouncer in heroku-buildpack-pgbouncer.


### PR DESCRIPTION
So that PgBouncer can use its recommended `c-ares` based DNS backend:
https://github.com/heroku/heroku-buildpack-pgbouncer/issues/188
https://www.pgbouncer.org/install.html
https://c-ares.org/

The package is named `libcares2` on Heroku-24 and `libc-ares2` on older stacks:
https://packages.ubuntu.com/noble/libcares2
https://packages.ubuntu.com/jammy/libc-ares2
https://packages.ubuntu.com/focal/libc-ares2

This only adds ~200 KB to the run image.

I've not added the corresponding headers to the build image, since:
- For the PgBouncer use-case they can instead be installed in the build environment used to compile the PgBouncer binaries.
- There don't seem to be many popular `c-ares` language bindings that people might use directly in their apps.

GUS-W-15826387.