### PR TITLE
Add `jq` to the run image for all stacks

### DIFF
--- a/heroku-20-build/setup.sh
+++ b/heroku-20-build/setup.sh
@@ -13,7 +13,6 @@ packages=(
   cmake
   gettext
   git
-  jq
   libacl1-dev
   libapt-pkg-dev
   libargon2-dev

--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -69,6 +69,7 @@ imagemagick-6.q16
 init-system-helpers
 iproute2
 iputils-tracepath
+jq
 language-pack-en
 language-pack-en-base
 less
@@ -187,6 +188,7 @@ libjbig0
 libjbig2dec0
 libjpeg-turbo8
 libjpeg8
+libjq1
 libjson-c4
 libk5crypto3
 libkeyutils1

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -48,6 +48,7 @@ packages=(
   imagemagick
   iproute2
   iputils-tracepath
+  jq # Used by Heroku Exec at run time, and buildpacks at build time.
   language-pack-en
   less
   libaom0

--- a/heroku-22-build/setup.sh
+++ b/heroku-22-build/setup.sh
@@ -13,7 +13,6 @@ packages=(
   cmake
   gettext
   git
-  jq
   libacl1-dev
   libapt-pkg-dev
   libargon2-dev

--- a/heroku-22/installed-packages.txt
+++ b/heroku-22/installed-packages.txt
@@ -68,6 +68,7 @@ imagemagick-6.q16
 init-system-helpers
 iproute2
 iputils-tracepath
+jq
 language-pack-en
 language-pack-en-base
 less
@@ -188,6 +189,7 @@ libjbig0
 libjbig2dec0
 libjpeg-turbo8
 libjpeg8
+libjq1
 libjson-c5
 libk5crypto3
 libkeyutils1

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -48,6 +48,7 @@ packages=(
   imagemagick
   iproute2
   iputils-tracepath
+  jq # Used by Heroku Exec at run time, and buildpacks at build time.
   language-pack-en
   less
   libaom3

--- a/heroku-24-build/setup.sh
+++ b/heroku-24-build/setup.sh
@@ -12,7 +12,6 @@ packages=(
   cmake
   gettext # Internationalization utils used by Django, Rails etc.
   git
-  jq
   libargon2-dev
   libbsd-dev
   libbz2-dev

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -52,6 +52,7 @@ inetutils-telnet
 init-system-helpers
 iproute2
 iputils-tracepath
+jq
 keyboxd
 less
 libacl1
@@ -148,6 +149,7 @@ libjansson4
 libjbig0
 libjpeg-turbo8
 libjpeg8
+libjq1
 libjson-c5
 libjxl0.7
 libk5crypto3

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -52,6 +52,7 @@ inetutils-telnet
 init-system-helpers
 iproute2
 iputils-tracepath
+jq
 keyboxd
 less
 libacl1
@@ -148,6 +149,7 @@ libjansson4
 libjbig0
 libjpeg-turbo8
 libjpeg8
+libjq1
 libjson-c5
 libjxl0.7
 libk5crypto3

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -50,6 +50,7 @@ packages=(
   inetutils-telnet
   iproute2 # For `ip`, used by Heroku Exec.
   iputils-tracepath
+  jq # Used by Heroku Exec at run time, and buildpacks at build time.
   less
   libargon2-1 # Used by the PHP runtime.
   libass9 # Used by FFmpeg in heroku-buildpack-activestorage-preview.


### PR DESCRIPTION
So that Heroku Exec's init script can use it instead of Python's `json` module for extracting keys out of the Heroku Exec service API JSON response.

JQ was already in the build image, so this is a no-op for the build images, and only increases the run image size by ~470KB.

See:
https://gus.lightning.force.com/lightning/r/0D5EE00001l4DXC0A2/view
https://packages.ubuntu.com/noble/jq

GUS-W-15832128.