### PR TITLE
Add `nano` to Heroku-20 and Heroku-22

### DIFF
--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -543,6 +543,7 @@ mlock
 mount
 mtools
 mysql-common
+nano
 ncurses-base
 ncurses-bin
 netbase

--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -342,6 +342,7 @@ mlock
 mount
 mtools
 mysql-common
+nano
 ncurses-base
 ncurses-bin
 netbase

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -129,6 +129,7 @@ packages=(
   locales
   lsb-release
   make
+  nano # More usable than ed but still much smaller than vim.
   netcat-openbsd
   openssh-client
   openssh-server

--- a/heroku-22-build/installed-packages.txt
+++ b/heroku-22-build/installed-packages.txt
@@ -542,6 +542,7 @@ mlock
 mount
 mtools
 mysql-common
+nano
 ncurses-base
 ncurses-bin
 netbase

--- a/heroku-22/installed-packages.txt
+++ b/heroku-22/installed-packages.txt
@@ -347,6 +347,7 @@ mlock
 mount
 mtools
 mysql-common
+nano
 ncurses-base
 ncurses-bin
 netbase

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -132,6 +132,7 @@ packages=(
   locales
   lsb-release
   make
+  nano # More usable than ed but still much smaller than vim.
   netcat-openbsd
   openssh-client
   openssh-server


### PR DESCRIPTION
Nano was added to Heroku-24 in:
https://github.com/heroku/base-images/pull/284

This adds it to older stacks too, so that we don't have to:
(a) check which stack an app is running and remember what packages come with that stack when debugging in eg a support ticket,
(b) have to resort to using `ed` on older stacks.

This adds ~850KB to the run image for the older stacks.

See:
https://packages.ubuntu.com/jammy/nano
https://packages.ubuntu.com/focal/nano