### PR TITLE
Add `heroku` user to Heroku-20 and Heroku-22

### DIFF
--- a/heroku-20-cnb-build/Dockerfile
+++ b/heroku-20-cnb-build/Dockerfile
@@ -1,10 +1,7 @@
 ARG BASE_IMAGE=heroku/heroku:20-build
 FROM $BASE_IMAGE
 
-RUN groupadd heroku --gid 1000 \
-  && useradd heroku --uid 1000 --gid 1000 --shell /bin/bash --create-home \
-  && mkdir /app \
-  && chown heroku:heroku /app
+RUN mkdir /app && chown heroku:heroku /app
 
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#build-image
 USER heroku

--- a/heroku-20-cnb/Dockerfile
+++ b/heroku-20-cnb/Dockerfile
@@ -1,9 +1,7 @@
 ARG BASE_IMAGE=heroku/heroku:20
 FROM $BASE_IMAGE
 
-RUN groupadd heroku --gid 1000 \
-  && useradd heroku --uid 1000 --gid 1000 --shell /bin/bash --create-home \
-  && ln -s /workspace /app
+RUN ln -s /workspace /app
 
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#run-image
 USER heroku

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -176,6 +176,9 @@ apt-get remove -y --purge --auto-remove openjdk-8-jre-headless
 # https://bugs.launchpad.net/ubuntu/+source/ca-certificates-java/+bug/1771363
 test "$(file --brief /etc/ssl/certs/java/cacerts)" = "Java KeyStore"
 
+groupadd heroku --gid 1000
+useradd heroku --uid 1000 --gid 1000 --shell /bin/bash --create-home
+
 rm -rf /root/*
 rm -rf /tmp/*
 rm -rf /var/cache/apt/archives/*.deb

--- a/heroku-22-cnb-build/Dockerfile
+++ b/heroku-22-cnb-build/Dockerfile
@@ -1,10 +1,7 @@
 ARG BASE_IMAGE=heroku/heroku:22-build
 FROM $BASE_IMAGE
 
-RUN groupadd heroku --gid 1000 \
-  && useradd heroku --uid 1000 --gid 1000 --shell /bin/bash --create-home \
-  && mkdir /app \
-  && chown heroku:heroku /app
+RUN mkdir /app && chown heroku:heroku /app
 
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#build-image
 USER heroku

--- a/heroku-22-cnb/Dockerfile
+++ b/heroku-22-cnb/Dockerfile
@@ -1,9 +1,7 @@
 ARG BASE_IMAGE=heroku/heroku:22
 FROM $BASE_IMAGE
 
-RUN groupadd heroku --gid 1000 \
-  && useradd heroku --uid 1000 --gid 1000 --shell /bin/bash --create-home \
-  && ln -s /workspace /app
+RUN ln -s /workspace /app
 
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#run-image
 USER heroku

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -178,6 +178,9 @@ apt-get remove -y --purge --auto-remove openjdk-8-jre-headless
 # https://bugs.launchpad.net/ubuntu/+source/ca-certificates-java/+bug/1771363
 test "$(file --brief /etc/ssl/certs/java/cacerts)" = "Java KeyStore"
 
+groupadd heroku --gid 1000
+useradd heroku --uid 1000 --gid 1000 --shell /bin/bash --create-home
+
 rm -rf /root/*
 rm -rf /tmp/*
 rm -rf /var/cache/apt/archives/*.deb


### PR DESCRIPTION
This moves the `heroku` user creation step from the CNB-only Heroku-20/22 image variants down into the main Heroku-20/22 base image, for parity with the Heroku-24 base-image:
https://github.com/heroku/base-images/blob/2323b38c808bb4eb555bf5965148f6882b987bd8/heroku-24/setup.sh#L141-L142

This:
- Improves consistency across all of our images.
- Means users that wish to switch to a non-root user for security best practices can do so across all stacks without having to create their own non-root user first.

The default user for each image remains unchanged (see table in README), as changing that would be a more significant breaking change.

GUS-W-16186022.