### PR TITLE
Update CI to Ubuntu 24.04 runner images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ permissions:
 
 jobs:
   shellcheck:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run shellcheck
         run: find . -type f \( -name "*.sh" -o -path "*/bin/*" \) ! -name '*.jq' | xargs -t shellcheck
   build-stack:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - shellcheck
     env:

--- a/tools/bin/install-heroku-files
+++ b/tools/bin/install-heroku-files
@@ -15,6 +15,7 @@ echo "127.0.0.1 localhost localhost.localdomain" > "$IMG_MNT/etc/hosts"
 echo "heroku-runtime" > "$IMG_MNT/etc/hostname"
 
 for f in etc/profile etc/bash.bashrc; do
+  # shellcheck disable=SC2028 # https://www.shellcheck.net/wiki/SC2028
   echo "export PS1='\\[\\033[01;34m\\]\\w\\[\\033[00m\\] \\[\\033[01;32m\\]$ \\[\\033[00m\\]'" > "$IMG_MNT/$f"
 done
 


### PR DESCRIPTION
Now that Ubuntu 24.04 images are available on GitHub Actions, we can update from the Ubuntu 22.04 images.

The new image version includes a newer Shellcheck release, which requires that we ignore a new warning:
https://www.shellcheck.net/wiki/SC2028

See also:
https://github.com/actions/runner-images/issues/9848
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
https://salesforce.quip.com/bu6UA0KImOxJ#temp:C:GZRd13d2ce2d455470495cbd34cf

GUS-W-16238120.