### PR TITLE
Heroku-22: remove memory limitations from imagemagick

### DIFF
--- a/heroku-22/imagemagick-policy.xml
+++ b/heroku-22/imagemagick-policy.xml
@@ -1,10 +1,4 @@
 <policymap>
-  <policy domain="resource" name="memory" value="256MiB"/>
-  <policy domain="resource" name="map" value="512MiB"/>
-  <policy domain="resource" name="width" value="16KP"/>
-  <policy domain="resource" name="height" value="16KP"/>
-  <policy domain="resource" name="area" value="128MP"/>
-  <policy domain="resource" name="disk" value="1GiB"/>
   <policy domain="delegate" rights="none" pattern="URL" />
   <policy domain="delegate" rights="none" pattern="HTTPS" />
   <policy domain="delegate" rights="none" pattern="HTTP" />


### PR DESCRIPTION
The size and memory limitations are not useful as they don't check the system's limits, but are just hard-coded, see:
https://github.com/ImageMagick/ImageMagick/issues/396#issuecomment-319569255

And specially for containers, the limits are better set by the runtime.

It would be less troublesome if you could override the settings from this configuration file, but unfortunately you can't.