### PR TITLE
Add missing runtime libs to heroku-22 and heroku-24

### DIFF
--- a/heroku-22/installed-packages.txt
+++ b/heroku-22/installed-packages.txt
@@ -156,6 +156,7 @@ libgdk-pixbuf-2.0-0
 libgdk-pixbuf-xlib-2.0-0
 libgdk-pixbuf2.0-0
 libgdk-pixbuf2.0-common
+libgeoip1
 libgirepository-1.0-1
 libglib2.0-0
 libgmp10
@@ -173,6 +174,7 @@ libgssapi-krb5-2
 libharfbuzz-gobject0
 libharfbuzz-icu0
 libharfbuzz0b
+libhashkit2
 libhdf5-103-1
 libheif1
 libhogweed6
@@ -216,6 +218,7 @@ libmaxminddb0
 libmcrypt4
 libmd0
 libmemcached11
+libmemcachedutil2
 libmnl0
 libmount1
 libmp3lame0
@@ -225,6 +228,7 @@ libmpfr6
 libmysqlclient21
 libncurses6
 libncursesw6
+libnetpbm10
 libnettle8
 libnghttp2-14
 libnpth0
@@ -313,6 +317,7 @@ libvpx7
 libwebp7
 libwebpdemux2
 libwebpmux3
+libwmf-0.2-7
 libwmflite-0.2-7
 libwrap0
 libx11-6

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -73,6 +73,7 @@ packages=(
   libgd3
   libgdk-pixbuf2.0-0
   libgdk-pixbuf2.0-common
+  libgeoip1
   libgnutls-openssl27
   libgnutls30
   libgnutlsxx28
@@ -82,13 +83,16 @@ packages=(
   libharfbuzz-gobject0
   libharfbuzz-icu0
   libharfbuzz0b
+  libhashkit2
   libheif1
   liblzf1
   libmagickcore-6.q16-3-extra
   libmcrypt4
   libmemcached11
+  libmemcachedutil2
   libmp3lame0
   libmysqlclient21
+  libnetpbm10
   libnuma1
   libogg0
   libonig5
@@ -120,6 +124,7 @@ packages=(
   libwebp7
   libwebpdemux2
   libwebpmux3
+  libwmf-0.2-7
   libx264-163
   libx265-199
   libxcb-render0

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -122,6 +122,7 @@ libgdbm-compat4t64
 libgdbm6t64
 libgdk-pixbuf-2.0-0
 libgdk-pixbuf2.0-common
+libgirepository-1.0-1
 libglib2.0-0t64
 libgmp10
 libgnutls-openssl27t64
@@ -142,6 +143,7 @@ libheif1
 libhogweed6t64
 libhwy1t64
 libicu74
+libidn12
 libidn2-0
 libimagequant0
 libimath-3-1-29t64
@@ -175,6 +177,7 @@ libmatio11
 libmaxminddb0
 libmd0
 libmemcached11t64
+libmemcachedutil2t64
 libmnl0
 libmount1
 libmp3lame0
@@ -260,8 +263,10 @@ libvorbisenc2
 libvorbisfile3
 libvpx9
 libwebp7
+libwebpdecoder3
 libwebpdemux2
 libwebpmux3
+libwmf-0.2-7
 libwmflite-0.2-7
 libwrap0
 libx11-6

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -122,6 +122,7 @@ libgdbm-compat4t64
 libgdbm6t64
 libgdk-pixbuf-2.0-0
 libgdk-pixbuf2.0-common
+libgirepository-1.0-1
 libglib2.0-0t64
 libgmp10
 libgnutls-openssl27t64
@@ -142,6 +143,7 @@ libheif1
 libhogweed6t64
 libhwy1t64
 libicu74
+libidn12
 libidn2-0
 libimagequant0
 libimath-3-1-29t64
@@ -175,6 +177,7 @@ libmatio11
 libmaxminddb0
 libmd0
 libmemcached11t64
+libmemcachedutil2t64
 libmnl0
 libmount1
 libmp3lame0
@@ -260,8 +263,10 @@ libvorbisenc2
 libvorbisfile3
 libvpx9
 libwebp7
+libwebpdecoder3
 libwebpdemux2
 libwebpmux3
+libwmf-0.2-7
 libwmflite-0.2-7
 libwrap0
 libx11-6

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -65,12 +65,15 @@ packages=(
   libevent-pthreads-2.1-7
   libgd3
   libgdk-pixbuf-2.0-0
+  libgirepository-1.0-1 # Because libgirepository1.0-dev and libgirepository-1.0-dev are in the build image
   libgnutls-openssl27
   libgnutls30 # Used by the Ruby and PHP runtimes.
   libharfbuzz-icu0 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
+  libidn12 # Because libidn-dev is in the build image
   liblzf1 # Used by the PHP Redis extension.
   libmagickcore-6.q16-7-extra # Used by the PHP Imagick extension (using the `-extra` package for SVG support).
   libmemcached11 # Used by the PHP Memcached extension.
+  libmemcachedutil2t64 # Same -dev headers as libmemcached11
   libmp3lame0 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   libmysqlclient21
   libncurses6 # Used by the Ruby runtime.
@@ -90,6 +93,8 @@ packages=(
   libvorbisenc2 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   libvorbisfile3 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   libvpx9 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
+  libwebpdecoder3 # Same -dev headers as the other libwebp* packages that get pulled in already
+  libwmf-0.2-7 # Because libwmf-dev is in the build image
   libx264-164 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   libx265-199 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   libxslt1.1 # Used by the PHP runtime.


### PR DESCRIPTION
As a general rule, we make dynamic libraries available in the run base images if the packages containing headers for dynamic linking (typically named `lib…-dev`) are present in the build image.

This ensures that programs that dynamically link against libraries using these headers at build time (e.g. native extensions for various languages) work reliably at runtime.

A recent review of the list of packages on all stacks turned up a number of packages that aren't available at runtime, but have build time headers.

Ignoring `heroku-20` (as it is deprecated), and disregarding non-8-bit `libpcre…` libraries (which already are in the run images) as well as X11-related libraries, we're missing the following:

`heroku-22`:
- `libgeoip1` because of `libgeoip-dev`
- `libhashkit2` because of `libhashkit-dev`
- `libmemcachedutil2` because of `libmemcached-dev`
- `libnetpbm10` because of `libnetpbm10-dev`
- `libwmf-0.2-7` because of `libwmf-dev`

`heroku-24`:
- `libgirepository-1.0-1` because of `libgirepository1.0-dev` and `libgirepository-1.0-dev`
- `libidn12` because of `libidn-dev`
- `libmemcachedutil2t64` because of `libmemcached-dev`
- `libwebpdecoder3` because of `libwebp-dev`
- `libwmf-0.2-7` because of `libwmf-dev`

GUS-W-16381871