### PR TITLE
Publish `.nightly` tags nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
     schedule:
       - cron: "0 0 * * 1-5"
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - main
     tags:
       - v*
+    schedule:
+      - cron: "0 0 * * 1-5"
   pull_request:
 
 permissions:


### PR DESCRIPTION
Currently, the `.nightly` tags (e.g. `heroku/heroku:24.nightly`) are only published when we merge things to main. When no changes happen on `main` for a while, the `.nightly` tags might actually be behind the non-nightly tags. 

This updates the CI workflow to run Monday-Friday at midnight.