### PR TITLE
Add type-urw-base35 package to heroku-24

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -42,6 +42,7 @@ fontconfig
 fontconfig-config
 fonts-dejavu-core
 fonts-dejavu-mono
+fonts-urw-base35
 g++
 g++-13
 g++-13-x86-64-linux-gnu
@@ -175,6 +176,7 @@ libfftw3-double3
 libfido2-1
 libfontconfig-dev
 libfontconfig1
+libfontenc1
 libfreetype-dev
 libfreetype6
 libfribidi0
@@ -535,6 +537,8 @@ wget
 x11-common
 x11proto-core-dev
 x11proto-dev
+xfonts-encodings
+xfonts-utils
 xorg-sgml-doctools
 xtrans-dev
 xz-utils

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -42,6 +42,7 @@ fontconfig
 fontconfig-config
 fonts-dejavu-core
 fonts-dejavu-mono
+fonts-urw-base35
 g++
 g++-13
 g++-13-aarch64-linux-gnu
@@ -171,6 +172,7 @@ libfftw3-double3
 libfido2-1
 libfontconfig-dev
 libfontconfig1
+libfontenc1
 libfreetype-dev
 libfreetype6
 libfribidi0
@@ -522,6 +524,8 @@ wget
 x11-common
 x11proto-core-dev
 x11proto-dev
+xfonts-encodings
+xfonts-utils
 xorg-sgml-doctools
 xtrans-dev
 xz-utils

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -29,6 +29,7 @@ fontconfig
 fontconfig-config
 fonts-dejavu-core
 fonts-dejavu-mono
+fonts-urw-base35
 gcc-14-base
 gettext-base
 gir1.2-freedesktop
@@ -113,6 +114,7 @@ libffi8
 libfftw3-double3
 libfido2-1
 libfontconfig1
+libfontenc1
 libfreetype6
 libfribidi0
 libgcc-s1
@@ -324,6 +326,9 @@ ucf
 unzip
 util-linux
 wget
+x11-common
+xfonts-encodings
+xfonts-utils
 xz-utils
 zip
 zlib1g

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -29,6 +29,7 @@ fontconfig
 fontconfig-config
 fonts-dejavu-core
 fonts-dejavu-mono
+fonts-urw-base35
 gcc-14-base
 gettext-base
 gir1.2-freedesktop
@@ -113,6 +114,7 @@ libffi8
 libfftw3-double3
 libfido2-1
 libfontconfig1
+libfontenc1
 libfreetype6
 libfribidi0
 libgcc-s1
@@ -324,6 +326,9 @@ ucf
 unzip
 util-linux
 wget
+x11-common
+xfonts-encodings
+xfonts-utils
 xz-utils
 zip
 zlib1g

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -43,6 +43,8 @@ packages=(
   bzip2
   curl
   file
+  fonts-dejavu-core
+  fonts-dejavu-mono
   fonts-urw-base35 # ImageMagick's default type.xml config points to these, includes e.g. Courier or Helvetica
   gettext-base # For `envsubst`.
   gir1.2-harfbuzz-0.0 # Used by FFmpeg in heroku-buildpack-activestorage-preview.

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -43,6 +43,7 @@ packages=(
   bzip2
   curl
   file
+  fonts-urw-base35 # ImageMagick's default type.xml config points to these, includes e.g. Courier or Helvetica
   gettext-base # For `envsubst`.
   gir1.2-harfbuzz-0.0 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   gnupg


### PR DESCRIPTION
For example, the following command does not work anymore:

    convert -background white -fill purple -font Courier -pointsize 72 label:Heroku test.png

This is a pain to work around using the Apt buildpack, because the base `/etc/ImageMagick-6/type.xml` includes more specific mappings for the `gsfonts` and `type-urw-base35` package's font files with absolute paths, so users would have to produce a huge custom `type.xml` with changed paths for each font in the package, and then point ImageMagick to that config using the `MAGICK_FONT_PATH` environment variable.

GUS-W-16494478
