### PR TITLE
Add CTC check prior to tag promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
     steps:
       - name: Obtain CTC Lock via TPS API
         run: |
-          curl -vv -X PUT \
+          curl -sS -X PUT \
             -H "ACCEPT: application/json" \
             -H "Content-Type: application/json" \
             -H "Authorization: Token ${{ secrets.TPS_TOKEN }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,9 +207,9 @@ jobs:
           curl -vv -X PUT \
             -H "ACCEPT: application/json" \
             -H "Content-Type: application/json" \
-            -H "Authorization: Token ${{ secrets.tps_token }}" \
+            -H "Authorization: Token ${{ secrets.TPS_TOKEN }}" \
             -d '{"lock": {"sha": "${{ github.sha }}", "component_name": "${{ vars.tps_component }}"}}' \
-            ${{ secrets.tps_ctc_api_url }}
+            ${{ secrets.TPS_CTC_API_URL }}
 
           echo "successful"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,9 +211,6 @@ jobs:
             -d '{"lock": {"sha": "${{ github.sha }}", "component_name": "${{ vars.tps_component }}"}}' \
             ${{ secrets.TPS_CTC_API_URL }}
 
-          echo "successful"
-          exit 1
-
   promote-tags:
     if: github.ref_type == 'tag'
     name: "Promote heroku-${{ matrix.stack-version }} tags"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
             -H "Content-Type: application/json" \
             -H "Authorization: Token ${{ secrets.TPS_TOKEN }}" \
             -d '{"lock": {"sha": "${{ github.sha }}", "component_name": "${{ vars.tps_component }}"}}' \
-            ${{ secrets.TPS_CTC_API_URL }}
+            "${{ secrets.TPS_CTC_API_URL }}"
 
   promote-tags:
     if: github.ref_type == 'tag'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,10 +197,28 @@ jobs:
             done
           done
 
+  ctc-check:
+    name: Obtain CTC Lock
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Obtain CTC Lock via TPS API
+        run: |
+          curl -vv -X PUT \
+            -H "ACCEPT: application/json" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Token ${{ secrets.tps_token }}" \
+            -d '{"lock": {"sha": "${{ github.sha }}", "component_name": "${{ vars.tps_component }}"}}' \
+            ${{ secrets.tps_ctc_api_url }}
+
+          echo "successful"
+          exit 1
+
   promote-tags:
     if: github.ref_type == 'tag'
     name: "Promote heroku-${{ matrix.stack-version }} tags"
     needs:
+      - ctc-check
       - publish-images
       - publish-indices
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This adds a CTC check prior to promoting to main tags e.g. from `heroku/heroku:24.v133` to `heroku/heroku:24`. This should prevent releases during deployment moratoriums.