### PR TITLE
Fail CTC check on 400+ responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,8 @@ jobs:
     steps:
       - name: Obtain CTC Lock via TPS API
         run: |
-          curl -sS -X PUT \
+          curl -sS --connect-timeout 5 --fail-with-body --retry-connrefused --retry 5 \
+            -X PUT \
             -H "ACCEPT: application/json" \
             -H "Content-Type: application/json" \
             -H "Authorization: Token ${{ secrets.TPS_TOKEN }}" \


### PR DESCRIPTION
As @edmorley pointed out in https://github.com/heroku/base-images/pull/322#discussion_r1732576122, the CTC check won't actually fail as is. I've added `--fail-with-body` to curl so that the command does fail with a non-zero exit if the HTTP status code is 400 or higher.

I've also added some retries to reduce flakiness.

GUS-W-16376259.