### PR TITLE
Reintroduce ghostscript for heroku-24

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -55,6 +55,7 @@ gcc-14-base
 gcc-x86-64-linux-gnu
 gettext
 gettext-base
+ghostscript
 gir1.2-freedesktop
 gir1.2-freedesktop-dev
 gir1.2-gdkpixbuf-2.0
@@ -106,6 +107,9 @@ libatomic1
 libattr1
 libaudit-common
 libaudit1
+libavahi-client3
+libavahi-common-data
+libavahi-common3
 libbinutils
 libblkid-dev
 libblkid1
@@ -138,6 +142,7 @@ libcrypt-dev
 libcrypt1
 libctf-nobfd0
 libctf0
+libcups2t64
 libcurl3t64-gnutls
 libcurl4-openssl-dev
 libcurl4t64
@@ -145,6 +150,7 @@ libdatrie1
 libdav1d-dev
 libdav1d7
 libdb5.3t64
+libdbus-1-3
 libde265-0
 libde265-dev
 libdebconfclient0
@@ -212,6 +218,9 @@ libgomp1
 libgpg-error0
 libgprofng0
 libgraphite2-3
+libgs-common
+libgs10
+libgs10-common
 libgssapi-krb5-2
 libgssrpc4t64
 libharfbuzz-gobject0
@@ -235,6 +244,7 @@ libidn-dev
 libidn12
 libidn2-0
 libidn2-dev
+libijs-0.35
 libimagequant0
 libimath-3-1-29t64
 libimath-dev
@@ -243,6 +253,7 @@ libitm1
 libjansson4
 libjbig-dev
 libjbig0
+libjbig2dec0
 libjpeg-dev
 libjpeg-turbo8
 libjpeg-turbo8-dev
@@ -335,6 +346,7 @@ libpam0g
 libpango-1.0-0
 libpangocairo-1.0-0
 libpangoft2-1.0-0
+libpaper1
 libpcre2-16-0
 libpcre2-32-0
 libpcre2-8-0
@@ -504,6 +516,7 @@ perl-modules-5.38
 pinentry-curses
 pkgconf
 pkgconf-bin
+poppler-data
 poppler-utils
 postgresql-client-16
 postgresql-client-common

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -55,6 +55,7 @@ gcc-14-base
 gcc-aarch64-linux-gnu
 gettext
 gettext-base
+ghostscript
 gir1.2-freedesktop
 gir1.2-freedesktop-dev
 gir1.2-gdkpixbuf-2.0
@@ -102,6 +103,9 @@ libatomic1
 libattr1
 libaudit-common
 libaudit1
+libavahi-client3
+libavahi-common-data
+libavahi-common3
 libbinutils
 libblkid-dev
 libblkid1
@@ -134,6 +138,7 @@ libcrypt-dev
 libcrypt1
 libctf-nobfd0
 libctf0
+libcups2t64
 libcurl3t64-gnutls
 libcurl4-openssl-dev
 libcurl4t64
@@ -141,6 +146,7 @@ libdatrie1
 libdav1d-dev
 libdav1d7
 libdb5.3t64
+libdbus-1-3
 libde265-0
 libde265-dev
 libdebconfclient0
@@ -205,6 +211,9 @@ libgomp1
 libgpg-error0
 libgprofng0
 libgraphite2-3
+libgs-common
+libgs10
+libgs10-common
 libgssapi-krb5-2
 libgssrpc4t64
 libharfbuzz-gobject0
@@ -228,6 +237,7 @@ libidn-dev
 libidn12
 libidn2-0
 libidn2-dev
+libijs-0.35
 libimagequant0
 libimath-3-1-29t64
 libimath-dev
@@ -236,6 +246,7 @@ libitm1
 libjansson4
 libjbig-dev
 libjbig0
+libjbig2dec0
 libjpeg-dev
 libjpeg-turbo8
 libjpeg-turbo8-dev
@@ -328,6 +339,7 @@ libpam0g
 libpango-1.0-0
 libpangocairo-1.0-0
 libpangoft2-1.0-0
+libpaper1
 libpcre2-16-0
 libpcre2-32-0
 libpcre2-8-0
@@ -496,6 +508,7 @@ perl-modules-5.38
 pinentry-curses
 pkgconf
 pkgconf-bin
+poppler-data
 poppler-utils
 postgresql-client-16
 postgresql-client-common

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -32,6 +32,7 @@ fonts-dejavu-mono
 fonts-urw-base35
 gcc-14-base
 gettext-base
+ghostscript
 gir1.2-freedesktop
 gir1.2-glib-2.0
 gir1.2-harfbuzz-0.0
@@ -67,6 +68,9 @@ libassuan0
 libattr1
 libaudit-common
 libaudit1
+libavahi-client3
+libavahi-common-data
+libavahi-common3
 libbinutils
 libblkid1
 libbpf1
@@ -89,11 +93,13 @@ libcom-err2
 libcrypt1
 libctf-nobfd0
 libctf0
+libcups2t64
 libcurl3t64-gnutls
 libcurl4t64
 libdatrie1
 libdav1d7
 libdb5.3t64
+libdbus-1-3
 libde265-0
 libdebconfclient0
 libdeflate0
@@ -132,6 +138,9 @@ libgomp1
 libgpg-error0
 libgprofng0
 libgraphite2-3
+libgs-common
+libgs10
+libgs10-common
 libgssapi-krb5-2
 libharfbuzz-gobject0
 libharfbuzz-icu0
@@ -143,12 +152,16 @@ libheif-plugin-libde265
 libheif1
 libhogweed6t64
 libhwy1t64
+libice6
 libicu74
+libidn12
 libidn2-0
+libijs-0.35
 libimagequant0
 libimath-3-1-29t64
 libjansson4
 libjbig0
+libjbig2dec0
 libjpeg-turbo8
 libjpeg8
 libjq1
@@ -205,6 +218,7 @@ libpam0g
 libpango-1.0-0
 libpangocairo-1.0-0
 libpangoft2-1.0-0
+libpaper1
 libpcre2-8-0
 libperl5.38t64
 libpixman-1-0
@@ -231,6 +245,7 @@ libsemanage2
 libsepol2
 libsframe1
 libsharpyuv0
+libsm6
 libsmartcols1
 libsodium23
 libspeex1
@@ -280,6 +295,7 @@ libxml2
 libxpm4
 libxrender1
 libxslt1.1
+libxt6t64
 libxtables12
 libxxhash0
 libyaml-0-2
@@ -308,6 +324,7 @@ perl
 perl-base
 perl-modules-5.38
 pinentry-curses
+poppler-data
 poppler-utils
 postgresql-client-16
 postgresql-client-common

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -32,6 +32,7 @@ fonts-dejavu-mono
 fonts-urw-base35
 gcc-14-base
 gettext-base
+ghostscript
 gir1.2-freedesktop
 gir1.2-glib-2.0
 gir1.2-harfbuzz-0.0
@@ -67,6 +68,9 @@ libassuan0
 libattr1
 libaudit-common
 libaudit1
+libavahi-client3
+libavahi-common-data
+libavahi-common3
 libbinutils
 libblkid1
 libbpf1
@@ -89,11 +93,13 @@ libcom-err2
 libcrypt1
 libctf-nobfd0
 libctf0
+libcups2t64
 libcurl3t64-gnutls
 libcurl4t64
 libdatrie1
 libdav1d7
 libdb5.3t64
+libdbus-1-3
 libde265-0
 libdebconfclient0
 libdeflate0
@@ -132,6 +138,9 @@ libgomp1
 libgpg-error0
 libgprofng0
 libgraphite2-3
+libgs-common
+libgs10
+libgs10-common
 libgssapi-krb5-2
 libharfbuzz-gobject0
 libharfbuzz-icu0
@@ -143,12 +152,16 @@ libheif-plugin-libde265
 libheif1
 libhogweed6t64
 libhwy1t64
+libice6
 libicu74
+libidn12
 libidn2-0
+libijs-0.35
 libimagequant0
 libimath-3-1-29t64
 libjansson4
 libjbig0
+libjbig2dec0
 libjpeg-turbo8
 libjpeg8
 libjq1
@@ -205,6 +218,7 @@ libpam0g
 libpango-1.0-0
 libpangocairo-1.0-0
 libpangoft2-1.0-0
+libpaper1
 libpcre2-8-0
 libperl5.38t64
 libpixman-1-0
@@ -231,6 +245,7 @@ libsemanage2
 libsepol2
 libsframe1
 libsharpyuv0
+libsm6
 libsmartcols1
 libsodium23
 libspeex1
@@ -280,6 +295,7 @@ libxml2
 libxpm4
 libxrender1
 libxslt1.1
+libxt6t64
 libxtables12
 libxxhash0
 libyaml-0-2
@@ -308,6 +324,7 @@ perl
 perl-base
 perl-modules-5.38
 pinentry-curses
+poppler-data
 poppler-utils
 postgresql-client-16
 postgresql-client-common

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -47,6 +47,7 @@ packages=(
   fonts-dejavu-mono
   fonts-urw-base35 # ImageMagick's default type.xml config points to these, includes e.g. Courier or Helvetica
   gettext-base # For `envsubst`.
+  ghostscript # Used by ImageMagick's PDF functionality
   gir1.2-harfbuzz-0.0 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   gnupg
   imagemagick


### PR DESCRIPTION
We've received some feedback about ghostscript (which was included in Heroku-18, Heroku-20, and Heroku-22, but was not included in Heroku-24):

> Removing ghostscript has an effect on imagemagick based libraries on Python(eg. wand etc). We had to revert to using a custom buildpack(https://github.com/Airbase/heroku-buildpack-ghostscript) to install these back. The imagemagic libraries are fairly common in the python world to do PDF, image manipulations, thumb-nailing etc.

So, while not being used directly a ton, folks do use ghostscript via ImageMagick to work with PDFs.

~Other packages we could consider:~

~- libgs10~
~- gsfonts~

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000020eu4IYAQ/view)