### PR TITLE
Fix cron schedule indentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - main
     tags:
       - v*
-    schedule:
+  schedule:
       - cron: "0 0 * * 1-5"
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     tags:
       - v*
   schedule:
-      - cron: "0 0 * * 1-5"
+    - cron: "0 0 * * 1-5"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
As @edmorley pointed out in https://github.com/heroku/base-images/pull/320#discussion_r1732592521, the cron schedule isn't working. This should get it to a working state.