### PR TITLE
Update manifest.yml to use tag rather than sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           path: /tmp/heroku-${{ matrix.stack-version }}*
       - name: Upload heroku runtime images to staging
         run: |
-          bin/upload-runtime-images.sh ${{ matrix.stack-version }} ${{ github.sha }}
+          bin/upload-runtime-images.sh ${{ matrix.stack-version }} ${{ github.ref_name }}
 
   publish-images:
     if: github.ref_name == 'main' || github.ref_type == 'tag'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
             -H "ACCEPT: application/json" \
             -H "Content-Type: application/json" \
             -H "Authorization: Token ${{ secrets.TPS_TOKEN }}" \
-            -d '{"lock": {"sha": "${{ github.sha }}", "component_name": "${{ vars.tps_component }}"}}' \
+            -d '{"lock": {"sha": "${{ github.ref_name }}", "component_name": "${{ vars.tps_component }}"}}' \
             "${{ secrets.TPS_CTC_API_URL }}"
 
   promote-tags:


### PR DESCRIPTION
The current iteration of https://s3.amazonaws.com/heroku_stacks_production/manifest.yml.signed currently includes entries with git shas like this:

```
git_ref: b4689bb306581b71b29701c55ecd9c6efb730d9c
```

Prior to https://github.com/heroku/base-images/pull/318, git tags were used instead. e.g.:

```
git_ref: v105
```

This PR updates the CI action to use git tags, as before.

This PR additionally updates the CTC to use git tags too, since it's common to successive base images against the same sha.

GUS-W-17066497.