### PR TITLE
maint: add the AWS RDS cert bundles

### DIFF
--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -160,6 +160,18 @@ apt-get install -y --no-install-recommends "${packages[@]}"
 
 cp /build/imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
 
+# Install AWS RDS global CA bundle (https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions)
+mkdir -p /usr/local/share/ca-certificates/rds-ca-certs
+pushd /usr/local/share/ca-certificates/rds-ca-certs
+wget -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /tmp/global-bundle.pem
+echo "ed2b625ceeca0ebacf413972c33acbeb65a6c6b94d0c6434f1bb006cd4904ede /tmp/global-bundle.pem" | sha256sum -c
+awk '
+  split_after == 1 {n++;split_after=0}
+  /-----END CERTIFICATE-----/ {split_after=1}
+  {print > "/usr/local/share/ca-certificates/rds-ca-certs/rds-ca" n ".crt"}' < /tmp/global-bundle.pem
+popd
+update-ca-certificates
+
 # Install ca-certificates-java so that the JVM buildpacks can configure Java apps to use the Java certs
 # store in the base image instead of the one that ships in each JRE release, allowing certs to be updated
 # via base image updates. Generation of the `cacerts` file occurs in a post-install script which requires

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -32,6 +32,7 @@ packages=(
   apt-utils
   bind9-host
   bzip2
+  ca-certificates
   coreutils
   curl
   dnsutils
@@ -165,6 +166,18 @@ packages=(
 apt-get install -y --no-install-recommends "${packages[@]}"
 
 cp /build/imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
+
+# Install AWS RDS global CA bundle (https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions)
+mkdir -p /usr/local/share/ca-certificates/rds-ca-certs
+pushd /usr/local/share/ca-certificates/rds-ca-certs
+wget -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /tmp/global-bundle.pem
+echo "ed2b625ceeca0ebacf413972c33acbeb65a6c6b94d0c6434f1bb006cd4904ede /tmp/global-bundle.pem" | sha256sum
+awk '
+  split_after == 1 {n++;split_after=0}
+  /-----END CERTIFICATE-----/ {split_after=1}
+  {print > "/usr/local/share/ca-certificates/rds-ca-certs/rds-ca" n ".crt"}' < /tmp/global-bundle.pem
+popd
+update-ca-certificates
 
 # Install ca-certificates-java so that the JVM buildpacks can configure Java apps to use the Java certs
 # store in the base image instead of the one that ships in each JRE release, allowing certs to be updated

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -129,6 +129,18 @@ apt-get install -y --no-install-recommends "${packages[@]}"
 # https://github.com/docker-library/docs/blob/master/ubuntu/README.md#locales
 locale-gen en_US.UTF-8
 
+# Install AWS RDS global CA bundle (https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions)
+mkdir -p /usr/local/share/ca-certificates/rds-ca-certs
+pushd /usr/local/share/ca-certificates/rds-ca-certs
+wget -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /tmp/global-bundle.pem
+echo "ed2b625ceeca0ebacf413972c33acbeb65a6c6b94d0c6434f1bb006cd4904ede /tmp/global-bundle.pem" | sha256sum -c
+awk '
+  split_after == 1 {n++;split_after=0}
+  /-----END CERTIFICATE-----/ {split_after=1}
+  {print > "/usr/local/share/ca-certificates/rds-ca-certs/rds-ca" n ".crt"}' < /tmp/global-bundle.pem
+popd
+update-ca-certificates
+
 # Install ca-certificates-java so that the JVM buildpacks can configure Java apps to use the Java certs
 # store in the base image instead of the one that ships in each JRE release, allowing certs to be updated
 # via base image updates. Generation of the `cacerts` file occurs in a post-install script which only runs
@@ -140,6 +152,7 @@ apt-get remove -y --purge --auto-remove default-jre-headless
 # https://github.com/heroku/base-images/pull/103#issuecomment-389544431
 # https://bugs.launchpad.net/ubuntu/+source/ca-certificates-java/+bug/1771363
 test "$(file --brief /etc/ssl/certs/java/cacerts)" = "Java KeyStore"
+
 
 # Ubuntu 24.04 ships with a default user and group named 'ubuntu' (with user+group ID of 1000)
 # that we have to remove before creating our own (`userdel` will remove the group too).


### PR DESCRIPTION
Reopening https://github.com/heroku/base-images/pull/238

This PR will add RDS CA bundle to the stacks. This will allow customers to set their postgres connections to `verify-full` when connecting to a essential tier database. I opted not to chain the commands together into a list. I found that it made debugging failures much harder. For some reason 22 needed to have `ca-certificates` package added, without it the wget will fail and the `update-ca-certificates` will not exist

## Testing
Before changes
```
root@aecdd0b8a9ae / [heroku/heroku:24]
docker > psql 'postgres://udkn8531065hs2:<redacted>@c4fuk4g4mva0ni.cluster-cmgvywijhzgr.us-east-1.rds.amazonaws.com:5432/d7434taaso5gbu?sslmode=verify-full&sslrootcert=system'
psql: error: connection to server at "c4fuk4g4mva0ni.cluster-cmgvywijhzgr.us-east-1.rds.amazonaws.com" (100.64.1.39), port 5432 failed: SSL error: certificate verify failed
```

Built the images
Ran this pattern in all 3 images
```
docker run -it --rm --platform=linux/amd64 33f6435378c7 bash
root@13d8683a53ca:/# psql 'postgres://udkn8531065hs2:<redacted>@c4fuk4g4mva0ni.cluster-cmgvywijhzgr.us-east-1.rds.amazonaws.com:5432/d7434taaso5gbu?sslmode=verify-full&sslrootcert=system'
psql (16.4 (Ubuntu 16.4-1.pgdg22.04+2), server 15.7)
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

root@6cf200a37298:/# curl -s https://cdn.azul.com/zulu/bin/zulu17.40.19-ca-jdk17.0.6-linux_x64.tar.gz | tar xz
root@6cf200a37298:/# zulu17.40.19-ca-jdk17.0.6-linux_x64/bin/keytool -list -v -keystore /etc/ssl/certs/java/cacerts | grep "Amazon RDS" | grep "Owner" | wc -l
Enter keystore password:
...

100
```