### PR TITLE
Fixing reproducibility error introduced by 24-CNB vs 24-Heroku

### DIFF
--- a/heroku-24-build/Dockerfile
+++ b/heroku-24-build/Dockerfile
@@ -14,3 +14,7 @@ ENV CNB_GROUP_ID=1000
 # Stack IDs are deprecated, but we still set this for backwards compatibility:
 # https://github.com/buildpacks/spec/blob/platform/0.13/platform.md#iobuildpacksstack-labels
 ENV CNB_STACK_ID="heroku-24"
+
+# Match HOME operation done in [heroku-22](https://github.com/usiegj00/base-images/blob/3bed84a6cf88bc6535b1ef18acbc454f88c854d8/heroku-22-cnb/Dockerfile#L17). 
+# This is related to [the user HOME issue exposed here](https://github.com/heroku/base-images/pull/332).
+ENV HOME=/workspace

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -154,8 +154,8 @@ test "$(file --brief /etc/ssl/certs/java/cacerts)" = "Java KeyStore"
 # that we have to remove before creating our own (`userdel` will remove the group too).
 userdel ubuntu --remove
 
-groupadd heroku --gid 1000
-useradd heroku --uid 1000 --gid 1000 --shell /bin/bash --create-home
+groupadd dyno --gid 1000
+useradd dyno --uid 1000 --gid 1000 --shell /bin/bash --home /app --create-home
 
 rm -rf /root/*
 rm -rf /tmp/*


### PR DESCRIPTION
The 24-Heroku stack adds a user like `u12345` and a `dyno` user, both with `HOME` of `/app`. The 24-CNB stack breaks this convention by introducing a `heroku` user with a `HOME` of `/home/heroku`. This prevents packages such as [fontconfig which expects .fonts to be available in HOME](https://www.freedesktop.org/software/fontconfig/fontconfig-user.html). 

In non-CNB builds, `HOME` and `/app` are the same, so a `/app/.fonts/this.ttf` is available as expected at runtime.

In CNB builds, these are different, so the same font would be at `/app/.fonts/this.ttf`, while the runtime path searched would be `/home/heroku/.fonts`.

This fix has been thoroughly tested and helps Heroku customers achieve better reproducibility and alignment with open standards.