### PR TITLE
Update installed packages for `libio-pty-perl` and `libipc-run-perl`

### DIFF
--- a/heroku-20-build/installed-packages-amd64.txt
+++ b/heroku-20-build/installed-packages-amd64.txt
@@ -264,6 +264,8 @@ libijs-0.35
 libilmbase-dev
 libilmbase24
 libimagequant0
+libio-pty-perl
+libipc-run-perl
 libisl22
 libitm1
 libjbig-dev

--- a/heroku-20/installed-packages-amd64.txt
+++ b/heroku-20/installed-packages-amd64.txt
@@ -182,6 +182,8 @@ libidn2-0
 libijs-0.35
 libilmbase24
 libimagequant0
+libio-pty-perl
+libipc-run-perl
 libisl22
 libitm1
 libjbig0

--- a/heroku-22-build/installed-packages-amd64.txt
+++ b/heroku-22-build/installed-packages-amd64.txt
@@ -265,7 +265,9 @@ libijs-0.35
 libilmbase-dev
 libilmbase25
 libimagequant0
+libio-pty-perl
 libip4tc2
+libipc-run-perl
 libisl23
 libitm1
 libjbig-dev

--- a/heroku-22/installed-packages-amd64.txt
+++ b/heroku-22/installed-packages-amd64.txt
@@ -183,7 +183,9 @@ libidn2-0
 libijs-0.35
 libilmbase25
 libimagequant0
+libio-pty-perl
 libip4tc2
+libipc-run-perl
 libisl23
 libitm1
 libjbig0

--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -248,6 +248,8 @@ libijs-0.35
 libimagequant0
 libimath-3-1-29t64
 libimath-dev
+libio-pty-perl
+libipc-run-perl
 libisl23
 libitm1
 libjansson4

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -241,6 +241,8 @@ libijs-0.35
 libimagequant0
 libimath-3-1-29t64
 libimath-dev
+libio-pty-perl
+libipc-run-perl
 libisl23
 libitm1
 libjansson4

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -159,6 +159,8 @@ libidn2-0
 libijs-0.35
 libimagequant0
 libimath-3-1-29t64
+libio-pty-perl
+libipc-run-perl
 libjansson4
 libjbig0
 libjbig2dec0

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -159,6 +159,8 @@ libidn2-0
 libijs-0.35
 libimagequant0
 libimath-3-1-29t64
+libio-pty-perl
+libipc-run-perl
 libjansson4
 libjbig0
 libjbig2dec0


### PR DESCRIPTION
CI started failing [November 14](https://github.com/heroku/base-images/actions/runs/11847758462) since these packages have been added.

[GUS-W-14669613](https://gus--c.vf.force.com/a07EE00001gUpvuYAC)