### PR TITLE
Use component_slug for CTC check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
             -H "ACCEPT: application/json" \
             -H "Content-Type: application/json" \
             -H "Authorization: Token ${{ secrets.TPS_TOKEN }}" \
-            -d '{"lock": {"sha": "${{ github.sha }}", "component_name": "${{ vars.tps_component }}"}}' \
+            -d '{"lock": {"sha": "${{ github.sha }}", "component_slug": "${{ vars.tps_component }}"}}' \
             "${{ secrets.TPS_CTC_API_URL }}"
 
   promote-tags:


### PR DESCRIPTION
The `component_name` field is proper cased and mutable. We should use the slug which is stable and kebab cased.

[Internal Slack thread](https://salesforce-internal.slack.com/archives/C07TFBYRJCR/p1733251813353349?thread_ts=1733248541.839249&cid=C07TFBYRJCR)