### PR TITLE
Add `unminimize` to installed packages list for Heroku 24

### DIFF
--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -545,6 +545,7 @@ tar
 tzdata
 ubuntu-keyring
 ucf
+unminimize
 unzip
 util-linux
 uuid-dev

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -532,6 +532,7 @@ tar
 tzdata
 ubuntu-keyring
 ucf
+unminimize
 unzip
 util-linux
 uuid-dev

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -345,6 +345,7 @@ tar
 tzdata
 ubuntu-keyring
 ucf
+unminimize
 unzip
 util-linux
 wget

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -345,6 +345,7 @@ tar
 tzdata
 ubuntu-keyring
 ucf
+unminimize
 unzip
 util-linux
 wget


### PR DESCRIPTION
Related to: 
- https://bugs.launchpad.net/ubuntu/+source/unminimize/+bug/2072699
- https://changelogs.ubuntu.com/changelogs/pool/main/u/ubuntu-meta/ubuntu-meta_1.539.1/changelog