### PR TITLE
Update to PostgreSQL 17

### DIFF
--- a/heroku-20-build/installed-packages-amd64.txt
+++ b/heroku-20-build/installed-packages-amd64.txt
@@ -568,6 +568,7 @@ poppler-utils
 postgresql-client-17
 postgresql-client-common
 postgresql-common
+postgresql-common-dev
 postgresql-server-dev-17
 procps
 python-is-python3

--- a/heroku-20-build/installed-packages-amd64.txt
+++ b/heroku-20-build/installed-packages-amd64.txt
@@ -565,10 +565,10 @@ pinentry-curses
 pkg-config
 poppler-data
 poppler-utils
-postgresql-client-16
+postgresql-client-17
 postgresql-client-common
 postgresql-common
-postgresql-server-dev-16
+postgresql-server-dev-17
 procps
 python-is-python3
 python2

--- a/heroku-20-build/setup.sh
+++ b/heroku-20-build/setup.sh
@@ -77,7 +77,7 @@ packages=(
   libzstd-dev
   mercurial
   patchelf
-  postgresql-server-dev-16
+  postgresql-server-dev-17
   python3-dev
   ruby-dev
   zlib1g-dev

--- a/heroku-20/installed-packages-amd64.txt
+++ b/heroku-20/installed-packages-amd64.txt
@@ -361,7 +361,7 @@ perl-modules-5.30
 pinentry-curses
 poppler-data
 poppler-utils
-postgresql-client-16
+postgresql-client-17
 postgresql-client-common
 procps
 python-is-python3

--- a/heroku-20/installed-packages-amd64.txt
+++ b/heroku-20/installed-packages-amd64.txt
@@ -182,8 +182,6 @@ libidn2-0
 libijs-0.35
 libilmbase24
 libimagequant0
-libio-pty-perl
-libipc-run-perl
 libisl22
 libitm1
 libjbig0

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -135,7 +135,7 @@ packages=(
   openssh-server
   patch
   poppler-utils
-  postgresql-client-16
+  postgresql-client-17
   python-is-python3
   python3
   rename

--- a/heroku-22-build/installed-packages-amd64.txt
+++ b/heroku-22-build/installed-packages-amd64.txt
@@ -564,7 +564,7 @@ pinentry-curses
 pkg-config
 poppler-data
 poppler-utils
-postgresql-client-16
+postgresql-client-17
 postgresql-client-common
 procps
 python-is-python3

--- a/heroku-22-build/installed-packages-amd64.txt
+++ b/heroku-22-build/installed-packages-amd64.txt
@@ -265,9 +265,7 @@ libijs-0.35
 libilmbase-dev
 libilmbase25
 libimagequant0
-libio-pty-perl
 libip4tc2
-libipc-run-perl
 libisl23
 libitm1
 libjbig-dev

--- a/heroku-22/installed-packages-amd64.txt
+++ b/heroku-22/installed-packages-amd64.txt
@@ -370,7 +370,7 @@ perl-modules-5.34
 pinentry-curses
 poppler-data
 poppler-utils
-postgresql-client-16
+postgresql-client-17
 postgresql-client-common
 procps
 python-is-python3

--- a/heroku-22/installed-packages-amd64.txt
+++ b/heroku-22/installed-packages-amd64.txt
@@ -183,9 +183,7 @@ libidn2-0
 libijs-0.35
 libilmbase25
 libimagequant0
-libio-pty-perl
 libip4tc2
-libipc-run-perl
 libisl23
 libitm1
 libjbig0

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -143,7 +143,7 @@ packages=(
   openssh-server
   patch
   poppler-utils
-  postgresql-client-16
+  postgresql-client-17
   python-is-python3
   python3
   rename

--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -248,8 +248,6 @@ libijs-0.35
 libimagequant0
 libimath-3-1-29t64
 libimath-dev
-libio-pty-perl
-libipc-run-perl
 libisl23
 libitm1
 libjansson4

--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -520,7 +520,7 @@ pkgconf
 pkgconf-bin
 poppler-data
 poppler-utils
-postgresql-client-16
+postgresql-client-17
 postgresql-client-common
 procps
 python3

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -512,7 +512,7 @@ pkgconf
 pkgconf-bin
 poppler-data
 poppler-utils
-postgresql-client-16
+postgresql-client-17
 postgresql-client-common
 procps
 python3

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -241,8 +241,6 @@ libijs-0.35
 libimagequant0
 libimath-3-1-29t64
 libimath-dev
-libio-pty-perl
-libipc-run-perl
 libisl23
 libitm1
 libjansson4

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -159,8 +159,6 @@ libidn2-0
 libijs-0.35
 libimagequant0
 libimath-3-1-29t64
-libio-pty-perl
-libipc-run-perl
 libjansson4
 libjbig0
 libjbig2dec0

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -331,7 +331,7 @@ perl-modules-5.38
 pinentry-curses
 poppler-data
 poppler-utils
-postgresql-client-16
+postgresql-client-17
 postgresql-client-common
 procps
 readline-common

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -159,8 +159,6 @@ libidn2-0
 libijs-0.35
 libimagequant0
 libimath-3-1-29t64
-libio-pty-perl
-libipc-run-perl
 libjansson4
 libjbig0
 libjbig2dec0

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -331,7 +331,7 @@ perl-modules-5.38
 pinentry-curses
 poppler-data
 poppler-utils
-postgresql-client-16
+postgresql-client-17
 postgresql-client-common
 procps
 readline-common

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -110,7 +110,7 @@ packages=(
   openssh-server # Used by Heroku Exec.
   patch
   poppler-utils # For Rails Active Storage Previews PDF support.
-  postgresql-client-16 # We need `psql` (and not just libpq) for Shield DB workflows (where connections are only possible from the dyno).
+  postgresql-client-17 # We need `psql` (and not just libpq) for Shield DB workflows (where connections are only possible from the dyno).
   rsync
   socat
   tar


### PR DESCRIPTION
Updates stack image client/tooling packages to PG17. Release notes: https://www.postgresql.org/docs/17/release-17.html

Nothing scary/breaking for client package, libpq, or psql. There's a new client-side connection option, [sslnegotiation=direct](https://www.postgresql.org/docs/17/libpq-connect.html#LIBPQ-CONNECT-SSLNEGOTIATION), that performs a direct TLS handshake to avoid a round-trip negotiation. How this option will behave with Heroku's self-signed SSL certs is unknown right now; regression testing and benchmarking for this PG version will be under way soon.

GUS-W-17829187.