### PR TITLE
Update installed packages

### DIFF
--- a/heroku-20-build/installed-packages-amd64.txt
+++ b/heroku-20-build/installed-packages-amd64.txt
@@ -568,6 +568,7 @@ poppler-utils
 postgresql-client-16
 postgresql-client-common
 postgresql-common
+postgresql-common-dev
 postgresql-server-dev-16
 procps
 python-is-python3

--- a/heroku-20/installed-packages-amd64.txt
+++ b/heroku-20/installed-packages-amd64.txt
@@ -182,8 +182,6 @@ libidn2-0
 libijs-0.35
 libilmbase24
 libimagequant0
-libio-pty-perl
-libipc-run-perl
 libisl22
 libitm1
 libjbig0

--- a/heroku-22-build/installed-packages-amd64.txt
+++ b/heroku-22-build/installed-packages-amd64.txt
@@ -265,9 +265,7 @@ libijs-0.35
 libilmbase-dev
 libilmbase25
 libimagequant0
-libio-pty-perl
 libip4tc2
-libipc-run-perl
 libisl23
 libitm1
 libjbig-dev

--- a/heroku-22/installed-packages-amd64.txt
+++ b/heroku-22/installed-packages-amd64.txt
@@ -183,9 +183,7 @@ libidn2-0
 libijs-0.35
 libilmbase25
 libimagequant0
-libio-pty-perl
 libip4tc2
-libipc-run-perl
 libisl23
 libitm1
 libjbig0

--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -248,8 +248,6 @@ libijs-0.35
 libimagequant0
 libimath-3-1-29t64
 libimath-dev
-libio-pty-perl
-libipc-run-perl
 libisl23
 libitm1
 libjansson4

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -241,8 +241,6 @@ libijs-0.35
 libimagequant0
 libimath-3-1-29t64
 libimath-dev
-libio-pty-perl
-libipc-run-perl
 libisl23
 libitm1
 libjansson4

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -159,8 +159,6 @@ libidn2-0
 libijs-0.35
 libimagequant0
 libimath-3-1-29t64
-libio-pty-perl
-libipc-run-perl
 libjansson4
 libjbig0
 libjbig2dec0

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -159,8 +159,6 @@ libidn2-0
 libijs-0.35
 libimagequant0
 libimath-3-1-29t64
-libio-pty-perl
-libipc-run-perl
 libjansson4
 libjbig0
 libjbig2dec0


### PR DESCRIPTION
This reverts most of the "installed package list" changes introduced in https://github.com/heroku/base-images/pull/333, with the exception of `heroku-20-build` [which installs the `postgresql-server-dev-16` package](https://github.com/heroku/base-images/blob/090a999cda061ad91cf59120246df6eff1fe5f54/heroku-20-build/setup.sh#L80) - and instead adds the `postgresql-common-dev` package, which depend on `libio-pty-perl` and `libipc-run-perl`.

See https://www.postgresql.org/message-id/E1tiZyA-008IKN-8q%40atalia.postgresql.org for more details.