### PR TITLE
Add `liblttng-ust1` to Heroku-22 and Heroku-24

### DIFF
--- a/heroku-22-build/installed-packages-amd64.txt
+++ b/heroku-22-build/installed-packages-amd64.txt
@@ -305,6 +305,9 @@ liblqr-1-0-dev
 liblsan0
 libltdl-dev
 libltdl7
+liblttng-ust-common1
+liblttng-ust-ctl5
+liblttng-ust1
 liblz4-1
 liblz4-dev
 liblzf-dev

--- a/heroku-22/installed-packages-amd64.txt
+++ b/heroku-22/installed-packages-amd64.txt
@@ -204,6 +204,9 @@ liblmdb0
 liblqr-1-0
 liblsan0
 libltdl7
+liblttng-ust-common1
+liblttng-ust-ctl5
+liblttng-ust1
 liblz4-1
 liblzf1
 liblzma5

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -85,6 +85,7 @@ packages=(
   libharfbuzz0b
   libhashkit2
   libheif1
+  liblttng-ust1
   liblzf1
   libmagickcore-6.q16-3-extra
   libmcrypt4

--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -284,6 +284,9 @@ liblqr-1-0-dev
 liblsan0
 libltdl-dev
 libltdl7
+liblttng-ust-common1t64
+liblttng-ust-ctl5t64
+liblttng-ust1t64
 liblz4-1
 liblz4-dev
 liblzf-dev

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -277,6 +277,9 @@ liblqr-1-0-dev
 liblsan0
 libltdl-dev
 libltdl7
+liblttng-ust-common1t64
+liblttng-ust-ctl5t64
+liblttng-ust1t64
 liblz4-1
 liblz4-dev
 liblzf-dev

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -178,6 +178,9 @@ liblerc4
 liblmdb0
 liblqr-1-0
 libltdl7
+liblttng-ust-common1t64
+liblttng-ust-ctl5t64
+liblttng-ust1t64
 liblz4-1
 liblzf1
 liblzma5

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -178,6 +178,9 @@ liblerc4
 liblmdb0
 liblqr-1-0
 libltdl7
+liblttng-ust-common1t64
+liblttng-ust-ctl5t64
+liblttng-ust1t64
 liblz4-1
 liblzf1
 liblzma5

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -72,6 +72,7 @@ packages=(
   libgnutls-openssl27
   libgnutls30 # Used by the Ruby and PHP runtimes.
   libharfbuzz-icu0 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
+  liblttng-ust1 # Used by the .NET runtime.
   liblzf1 # Used by the PHP Redis extension.
   libmagickcore-6.q16-7-extra # Used by the PHP Imagick extension (using the `-extra` package for SVG support).
   libmemcached11 # Used by the PHP Memcached extension.


### PR DESCRIPTION
This PR adds the `liblttng-ust1` package (listed as an Ubuntu [22.04](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?tabs=dotnet9&pivots=os-linux-ubuntu-2204#dependencies-1) and [24.04](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?tabs=dotnet9&pivots=os-linux-ubuntu-2404#dependencies-1) .NET runtime dependency) to Heroku-22 and Heroku-24.