### PR TITLE
Add `media-types` package to Heroku-24 run-image

### DIFF
--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -312,6 +312,7 @@ login
 logsave
 lsb-release
 mawk
+media-types
 mlock
 mount
 mysql-common

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -312,6 +312,7 @@ login
 logsave
 lsb-release
 mawk
+media-types
 mlock
 mount
 mysql-common

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -106,6 +106,7 @@ packages=(
   libzip4 # Used by the PHP runtime.
   locales
   lsb-release
+  media-types # Provides /etc/mime.types, used by Python's `mimetypes` stdlib module.
   nano # More usable than ed but still much smaller than vim.
   netcat-openbsd
   openssh-client # Used by Heroku Exec.


### PR DESCRIPTION
Since it provides `/etc/mime.types`, which is one of the locations used by the Python `mimetypes` stdlib module:
https://github.com/python/cpython/blob/v3.13.7/Lib/mimetypes.py#L48-L58

In Heroku-22 and older the package is included due to it being a transitive dependency of other packages (such as system Python), however, for Heroku-24's smaller packages list we now need to include it explicitly.

The package is ~90KB.

Fixes #360.
GUS-W-19469378.